### PR TITLE
Track oracle delay for vamm fill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drift-idl-gen"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/drift-rs?rev=cb36575#cb36575bfecd45c0e13845d50b37cc5957edae52"
+source = "git+https://github.com/drift-labs/drift-rs?rev=ab3fec7a#ab3fec7a894eff048dff7bd7bcf3e24c9285cb91"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "drift-pubsub-client"
 version = "0.1.1"
-source = "git+https://github.com/drift-labs/drift-rs?rev=cb36575#cb36575bfecd45c0e13845d50b37cc5957edae52"
+source = "git+https://github.com/drift-labs/drift-rs?rev=ab3fec7a#ab3fec7a894eff048dff7bd7bcf3e24c9285cb91"
 dependencies = [
  "futures-util",
  "gjson",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "drift-rs"
 version = "1.0.0-alpha.16"
-source = "git+https://github.com/drift-labs/drift-rs?rev=cb36575#cb36575bfecd45c0e13845d50b37cc5957edae52"
+source = "git+https://github.com/drift-labs/drift-rs?rev=ab3fec7a#ab3fec7a894eff048dff7bd7bcf3e24c9285cb91"
 dependencies = [
  "abi_stable",
  "ahash 0.8.12",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2402,7 +2402,7 @@ dependencies = [
 [[package]]
 name = "jupiter-swap-api-client"
 version = "0.2.0"
-source = "git+https://github.com/jup-ag/jupiter-swap-api-client#70aaffd957d59c19588df86e92ce3b94f24f7d0b"
+source = "git+https://github.com/drift-labs/jupiter-swap-api-client?branch=patch%2F2025-12-28#6b07ee58ff4c3c5e4f0b9b35d13d9d37e4069202"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2413,7 +2413,7 @@ dependencies = [
  "serde_qs",
  "solana-account-decoder",
  "solana-sdk",
- "thiserror 2.0.17",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3567,22 +3567,19 @@ dependencies = [
 
 [[package]]
 name = "rmp"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
 dependencies = [
- "byteorder",
  "num-traits",
- "paste",
 ]
 
 [[package]]
 name = "rmp-serde"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
 dependencies = [
- "byteorder",
  "rmp",
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drift-idl-gen"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/drift-rs?rev=fd4b066#fd4b06621d9104500f3f17f1a3207bcb711344bd"
+source = "git+https://github.com/drift-labs/drift-rs?rev=cb36575#cb36575bfecd45c0e13845d50b37cc5957edae52"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "drift-pubsub-client"
 version = "0.1.1"
-source = "git+https://github.com/drift-labs/drift-rs?rev=fd4b066#fd4b06621d9104500f3f17f1a3207bcb711344bd"
+source = "git+https://github.com/drift-labs/drift-rs?rev=cb36575#cb36575bfecd45c0e13845d50b37cc5957edae52"
 dependencies = [
  "futures-util",
  "gjson",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "drift-rs"
 version = "1.0.0-alpha.16"
-source = "git+https://github.com/drift-labs/drift-rs?rev=fd4b066#fd4b06621d9104500f3f17f1a3207bcb711344bd"
+source = "git+https://github.com/drift-labs/drift-rs?rev=cb36575#cb36575bfecd45c0e13845d50b37cc5957edae52"
 dependencies = [
  "abi_stable",
  "ahash 0.8.12",
@@ -2411,7 +2411,7 @@ dependencies = [
 [[package]]
 name = "jupiter-swap-api-client"
 version = "0.2.0"
-source = "git+https://github.com/jup-ag/jupiter-swap-api-client#70aaffd957d59c19588df86e92ce3b94f24f7d0b"
+source = "git+https://github.com/drift-labs/jupiter-swap-api-client?branch=patch%2F2025-12-28#6b07ee58ff4c3c5e4f0b9b35d13d9d37e4069202"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2422,7 +2422,7 @@ dependencies = [
  "serde_qs",
  "solana-account-decoder",
  "solana-sdk",
- "thiserror 2.0.17",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3576,22 +3576,19 @@ dependencies = [
 
 [[package]]
 name = "rmp"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
 dependencies = [
- "byteorder",
  "num-traits",
- "paste",
 ]
 
 [[package]]
 name = "rmp-serde"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
 dependencies = [
- "byteorder",
  "rmp",
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drift-idl-gen"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/drift-rs?rev=17f57b7#17f57b718d34cc870d250123d09ea02ace1a257f"
+source = "git+https://github.com/drift-labs/drift-rs?rev=d6b482c#d6b482cef30c29980cca5b09b76817794d5ef0a8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "drift-pubsub-client"
 version = "0.1.1"
-source = "git+https://github.com/drift-labs/drift-rs?rev=17f57b7#17f57b718d34cc870d250123d09ea02ace1a257f"
+source = "git+https://github.com/drift-labs/drift-rs?rev=d6b482c#d6b482cef30c29980cca5b09b76817794d5ef0a8"
 dependencies = [
  "futures-util",
  "gjson",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "drift-rs"
 version = "1.0.0-alpha.16"
-source = "git+https://github.com/drift-labs/drift-rs?rev=17f57b7#17f57b718d34cc870d250123d09ea02ace1a257f"
+source = "git+https://github.com/drift-labs/drift-rs?rev=d6b482c#d6b482cef30c29980cca5b09b76817794d5ef0a8"
 dependencies = [
  "abi_stable",
  "ahash 0.8.12",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,6 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drift-idl-gen"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/drift-rs?rev=ab3fec7a#ab3fec7a894eff048dff7bd7bcf3e24c9285cb91"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1427,7 +1426,6 @@ dependencies = [
 [[package]]
 name = "drift-pubsub-client"
 version = "0.1.1"
-source = "git+https://github.com/drift-labs/drift-rs?rev=ab3fec7a#ab3fec7a894eff048dff7bd7bcf3e24c9285cb91"
 dependencies = [
  "futures-util",
  "gjson",
@@ -1447,7 +1445,6 @@ dependencies = [
 [[package]]
 name = "drift-rs"
 version = "1.0.0-alpha.16"
-source = "git+https://github.com/drift-labs/drift-rs?rev=ab3fec7a#ab3fec7a894eff048dff7bd7bcf3e24c9285cb91"
 dependencies = [
  "abi_stable",
  "ahash 0.8.12",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drift-idl-gen"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/drift-rs?rev=5590796#5590796d50b6049e74435b2497fd3312a9983f5a"
+source = "git+https://github.com/drift-labs/drift-rs?rev=fe743e4#fe743e48e289affc0712814954180b815fbeb0eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "drift-pubsub-client"
 version = "0.1.1"
-source = "git+https://github.com/drift-labs/drift-rs?rev=5590796#5590796d50b6049e74435b2497fd3312a9983f5a"
+source = "git+https://github.com/drift-labs/drift-rs?rev=fe743e4#fe743e48e289affc0712814954180b815fbeb0eb"
 dependencies = [
  "futures-util",
  "gjson",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "drift-rs"
 version = "1.0.0-alpha.16"
-source = "git+https://github.com/drift-labs/drift-rs?rev=5590796#5590796d50b6049e74435b2497fd3312a9983f5a"
+source = "git+https://github.com/drift-labs/drift-rs?rev=fe743e4#fe743e48e289affc0712814954180b815fbeb0eb"
 dependencies = [
  "abi_stable",
  "ahash 0.8.12",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,6 +1414,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drift-idl-gen"
 version = "0.2.0"
+source = "git+https://github.com/drift-labs/drift-rs?rev=fac78b#fac78b4383b0cfc2e3dd0d175b31808b3c8ee96c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1426,6 +1427,7 @@ dependencies = [
 [[package]]
 name = "drift-pubsub-client"
 version = "0.1.1"
+source = "git+https://github.com/drift-labs/drift-rs?rev=fac78b#fac78b4383b0cfc2e3dd0d175b31808b3c8ee96c"
 dependencies = [
  "futures-util",
  "gjson",
@@ -1445,6 +1447,7 @@ dependencies = [
 [[package]]
 name = "drift-rs"
 version = "1.0.0-alpha.16"
+source = "git+https://github.com/drift-labs/drift-rs?rev=fac78b#fac78b4383b0cfc2e3dd0d175b31808b3c8ee96c"
 dependencies = [
  "abi_stable",
  "ahash 0.8.12",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drift-idl-gen"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/drift-rs?rev=45528b#45528b97ca41e523545986ce2757da1c0e9c1cec"
+source = "git+https://github.com/drift-labs/drift-rs?rev=1689419#1689419bfd23f4c0ddb3838255dc9659197e9907"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "drift-pubsub-client"
 version = "0.1.1"
-source = "git+https://github.com/drift-labs/drift-rs?rev=45528b#45528b97ca41e523545986ce2757da1c0e9c1cec"
+source = "git+https://github.com/drift-labs/drift-rs?rev=1689419#1689419bfd23f4c0ddb3838255dc9659197e9907"
 dependencies = [
  "futures-util",
  "gjson",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "drift-rs"
 version = "1.0.0-alpha.16"
-source = "git+https://github.com/drift-labs/drift-rs?rev=45528b#45528b97ca41e523545986ce2757da1c0e9c1cec"
+source = "git+https://github.com/drift-labs/drift-rs?rev=1689419#1689419bfd23f4c0ddb3838255dc9659197e9907"
 dependencies = [
  "abi_stable",
  "ahash 0.8.12",
@@ -2335,15 +2335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3066,7 +3057,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -3088,7 +3079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drift-idl-gen"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/drift-rs?rev=1689419#1689419bfd23f4c0ddb3838255dc9659197e9907"
+source = "git+https://github.com/drift-labs/drift-rs?rev=5590796#5590796d50b6049e74435b2497fd3312a9983f5a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "drift-pubsub-client"
 version = "0.1.1"
-source = "git+https://github.com/drift-labs/drift-rs?rev=1689419#1689419bfd23f4c0ddb3838255dc9659197e9907"
+source = "git+https://github.com/drift-labs/drift-rs?rev=5590796#5590796d50b6049e74435b2497fd3312a9983f5a"
 dependencies = [
  "futures-util",
  "gjson",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "drift-rs"
 version = "1.0.0-alpha.16"
-source = "git+https://github.com/drift-labs/drift-rs?rev=1689419#1689419bfd23f4c0ddb3838255dc9659197e9907"
+source = "git+https://github.com/drift-labs/drift-rs?rev=5590796#5590796d50b6049e74435b2497fd3312a9983f5a"
 dependencies = [
  "abi_stable",
  "ahash 0.8.12",
@@ -2402,7 +2402,7 @@ dependencies = [
 [[package]]
 name = "jupiter-swap-api-client"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/jupiter-swap-api-client?branch=patch%2F2025-12-28#6b07ee58ff4c3c5e4f0b9b35d13d9d37e4069202"
+source = "git+https://github.com/drift-labs/jupiter-swap-api-client?branch=patch%2F2025-12-28#8a03d2a8e1017de9c54ee2c12532083812c13cf2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drift-idl-gen"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/drift-rs?rev=5bf8bd0#5bf8bd0f419f213413cec4eb410b3ea3b5fb4312"
+source = "git+https://github.com/drift-labs/drift-rs?rev=96fe2cf#96fe2cf88f31fee066145a0bf669739c65bae14f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "drift-pubsub-client"
 version = "0.1.1"
-source = "git+https://github.com/drift-labs/drift-rs?rev=5bf8bd0#5bf8bd0f419f213413cec4eb410b3ea3b5fb4312"
+source = "git+https://github.com/drift-labs/drift-rs?rev=96fe2cf#96fe2cf88f31fee066145a0bf669739c65bae14f"
 dependencies = [
  "futures-util",
  "gjson",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "drift-rs"
 version = "1.0.0-alpha.16"
-source = "git+https://github.com/drift-labs/drift-rs?rev=5bf8bd0#5bf8bd0f419f213413cec4eb410b3ea3b5fb4312"
+source = "git+https://github.com/drift-labs/drift-rs?rev=96fe2cf#96fe2cf88f31fee066145a0bf669739c65bae14f"
 dependencies = [
  "abi_stable",
  "ahash 0.8.12",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drift-idl-gen"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/drift-rs?rev=5590796#5590796d50b6049e74435b2497fd3312a9983f5a"
+source = "git+https://github.com/drift-labs/drift-rs?rev=4463af2#4463af275c8f5a11205a25ef9876603cd30cebd5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "drift-pubsub-client"
 version = "0.1.1"
-source = "git+https://github.com/drift-labs/drift-rs?rev=5590796#5590796d50b6049e74435b2497fd3312a9983f5a"
+source = "git+https://github.com/drift-labs/drift-rs?rev=4463af2#4463af275c8f5a11205a25ef9876603cd30cebd5"
 dependencies = [
  "futures-util",
  "gjson",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "drift-rs"
 version = "1.0.0-alpha.16"
-source = "git+https://github.com/drift-labs/drift-rs?rev=5590796#5590796d50b6049e74435b2497fd3312a9983f5a"
+source = "git+https://github.com/drift-labs/drift-rs?rev=4463af2#4463af275c8f5a11205a25ef9876603cd30cebd5"
 dependencies = [
  "abi_stable",
  "ahash 0.8.12",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drift-idl-gen"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/drift-rs?rev=d6b482c#d6b482cef30c29980cca5b09b76817794d5ef0a8"
+source = "git+https://github.com/drift-labs/drift-rs?rev=96fe2cf#96fe2cf88f31fee066145a0bf669739c65bae14f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "drift-pubsub-client"
 version = "0.1.1"
-source = "git+https://github.com/drift-labs/drift-rs?rev=d6b482c#d6b482cef30c29980cca5b09b76817794d5ef0a8"
+source = "git+https://github.com/drift-labs/drift-rs?rev=96fe2cf#96fe2cf88f31fee066145a0bf669739c65bae14f"
 dependencies = [
  "futures-util",
  "gjson",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "drift-rs"
 version = "1.0.0-alpha.16"
-source = "git+https://github.com/drift-labs/drift-rs?rev=d6b482c#d6b482cef30c29980cca5b09b76817794d5ef0a8"
+source = "git+https://github.com/drift-labs/drift-rs?rev=96fe2cf#96fe2cf88f31fee066145a0bf669739c65bae14f"
 dependencies = [
  "abi_stable",
  "ahash 0.8.12",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drift-idl-gen"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/drift-rs?rev=fe743e4#fe743e48e289affc0712814954180b815fbeb0eb"
+source = "git+https://github.com/drift-labs/drift-rs?rev=5bf8bd0#5bf8bd0f419f213413cec4eb410b3ea3b5fb4312"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "drift-pubsub-client"
 version = "0.1.1"
-source = "git+https://github.com/drift-labs/drift-rs?rev=fe743e4#fe743e48e289affc0712814954180b815fbeb0eb"
+source = "git+https://github.com/drift-labs/drift-rs?rev=5bf8bd0#5bf8bd0f419f213413cec4eb410b3ea3b5fb4312"
 dependencies = [
  "futures-util",
  "gjson",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "drift-rs"
 version = "1.0.0-alpha.16"
-source = "git+https://github.com/drift-labs/drift-rs?rev=fe743e4#fe743e48e289affc0712814954180b815fbeb0eb"
+source = "git+https://github.com/drift-labs/drift-rs?rev=5bf8bd0#5bf8bd0f419f213413cec4eb410b3ea3b5fb4312"
 dependencies = [
  "abi_stable",
  "ahash 0.8.12",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2443,6 +2443,7 @@ dependencies = [
  "axum",
  "clap",
  "crossbeam",
+ "dashmap",
  "dotenv",
  "drift-rs",
  "env_logger 0.11.8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drift-idl-gen"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/drift-rs?branch=trunk%2Fisolated-positions#41b125577ebc46f93d126ca2f9b8c68778546d4f"
+source = "git+https://github.com/drift-labs/drift-rs?rev=1689419#1689419bfd23f4c0ddb3838255dc9659197e9907"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "drift-pubsub-client"
 version = "0.1.1"
-source = "git+https://github.com/drift-labs/drift-rs?branch=trunk%2Fisolated-positions#41b125577ebc46f93d126ca2f9b8c68778546d4f"
+source = "git+https://github.com/drift-labs/drift-rs?rev=1689419#1689419bfd23f4c0ddb3838255dc9659197e9907"
 dependencies = [
  "futures-util",
  "gjson",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "drift-rs"
 version = "1.0.0-alpha.16"
-source = "git+https://github.com/drift-labs/drift-rs?branch=trunk%2Fisolated-positions#41b125577ebc46f93d126ca2f9b8c68778546d4f"
+source = "git+https://github.com/drift-labs/drift-rs?rev=1689419#1689419bfd23f4c0ddb3838255dc9659197e9907"
 dependencies = [
  "abi_stable",
  "ahash 0.8.12",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drift-idl-gen"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/drift-rs?rev=fac78b#fac78b4383b0cfc2e3dd0d175b31808b3c8ee96c"
+source = "git+https://github.com/drift-labs/drift-rs?rev=45528b#45528b97ca41e523545986ce2757da1c0e9c1cec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "drift-pubsub-client"
 version = "0.1.1"
-source = "git+https://github.com/drift-labs/drift-rs?rev=fac78b#fac78b4383b0cfc2e3dd0d175b31808b3c8ee96c"
+source = "git+https://github.com/drift-labs/drift-rs?rev=45528b#45528b97ca41e523545986ce2757da1c0e9c1cec"
 dependencies = [
  "futures-util",
  "gjson",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "drift-rs"
 version = "1.0.0-alpha.16"
-source = "git+https://github.com/drift-labs/drift-rs?rev=fac78b#fac78b4383b0cfc2e3dd0d175b31808b3c8ee96c"
+source = "git+https://github.com/drift-labs/drift-rs?rev=45528b#45528b97ca41e523545986ce2757da1c0e9c1cec"
 dependencies = [
  "abi_stable",
  "ahash 0.8.12",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drift-idl-gen"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/drift-rs?rev=4463af2#4463af275c8f5a11205a25ef9876603cd30cebd5"
+source = "git+https://github.com/drift-labs/drift-rs?rev=17f57b7#17f57b718d34cc870d250123d09ea02ace1a257f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "drift-pubsub-client"
 version = "0.1.1"
-source = "git+https://github.com/drift-labs/drift-rs?rev=4463af2#4463af275c8f5a11205a25ef9876603cd30cebd5"
+source = "git+https://github.com/drift-labs/drift-rs?rev=17f57b7#17f57b718d34cc870d250123d09ea02ace1a257f"
 dependencies = [
  "futures-util",
  "gjson",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "drift-rs"
 version = "1.0.0-alpha.16"
-source = "git+https://github.com/drift-labs/drift-rs?rev=4463af2#4463af275c8f5a11205a25ef9876603cd30cebd5"
+source = "git+https://github.com/drift-labs/drift-rs?rev=17f57b7#17f57b718d34cc870d250123d09ea02ace1a257f"
 dependencies = [
  "abi_stable",
  "ahash 0.8.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ axum = "0.8"
 clap = { version = "4.5.40", "features" = ["env", "derive"] }
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 dotenv = "0.15.0"
-drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "cb36575", features = ["unsafe_pub", "titan"] }
+drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "ab3fec7a", features = ["unsafe_pub", "titan"] }
 env_logger = "0.11"
 # DLOB 'trace' logs are expensive so compile them out
 log = { version = "0.4", features = ["max_level_trace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ axum = "0.8"
 clap = { version = "4.5.40", "features" = ["env", "derive"] }
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 dotenv = "0.15.0"
-drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "fd4b066", features = ["unsafe_pub", "titan"] }
+drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "cb36575", features = ["unsafe_pub", "titan"] }
 env_logger = "0.11"
 # DLOB 'trace' logs are expensive so compile them out
 log = { version = "0.4", features = ["max_level_trace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ axum = "0.8"
 clap = { version = "4.5.40", "features" = ["env", "derive"] }
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 dotenv = "0.15.0"
-drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "5bf8bd0", features = ["unsafe_pub", "titan"] }
+drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "96fe2cf", features = ["unsafe_pub", "titan"] }
 env_logger = "0.11"
 # DLOB 'trace' logs are expensive so compile them out
 log = { version = "0.4", features = ["max_level_trace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ axum = "0.8"
 clap = { version = "4.5.40", "features" = ["env", "derive"] }
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 dotenv = "0.15.0"
-drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "fac78b", features = ["unsafe_pub", "titan"] }
+drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "45528b", features = ["unsafe_pub", "titan"] }
 env_logger = "0.11"
 # DLOB 'trace' logs are expensive so compile them out
 log = { version = "0.4", features = ["max_level_trace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ axum = "0.8"
 clap = { version = "4.5.40", "features" = ["env", "derive"] }
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 dotenv = "0.15.0"
-drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "fe743e4", features = ["unsafe_pub", "titan"] }
+drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "5bf8bd0", features = ["unsafe_pub", "titan"] }
 env_logger = "0.11"
 # DLOB 'trace' logs are expensive so compile them out
 log = { version = "0.4", features = ["max_level_trace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ axum = "0.8"
 clap = { version = "4.5.40", "features" = ["env", "derive"] }
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 dotenv = "0.15.0"
-drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "d6b482c", features = ["unsafe_pub", "titan"] }
+drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "96fe2cf", features = ["unsafe_pub", "titan"] }
 env_logger = "0.11"
 # DLOB 'trace' logs are expensive so compile them out
 log = { version = "0.4", features = ["max_level_trace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ axum = "0.8"
 clap = { version = "4.5.40", "features" = ["env", "derive"] }
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 dotenv = "0.15.0"
-drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "5590796", features = ["unsafe_pub", "titan"] }
+drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "fe743e4", features = ["unsafe_pub", "titan"] }
 env_logger = "0.11"
 # DLOB 'trace' logs are expensive so compile them out
 log = { version = "0.4", features = ["max_level_trace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ axum = "0.8"
 clap = { version = "4.5.40", "features" = ["env", "derive"] }
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 dotenv = "0.15.0"
-drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "1689419", features = ["unsafe_pub", "titan"] }
+drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "5590796", features = ["unsafe_pub", "titan"] }
 env_logger = "0.11"
 # DLOB 'trace' logs are expensive so compile them out
 log = { version = "0.4", features = ["max_level_trace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ axum = "0.8"
 clap = { version = "4.5.40", "features" = ["env", "derive"] }
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 dotenv = "0.15.0"
-drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "ab3fec7a", features = ["unsafe_pub", "titan"] }
+drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "1321f1", features = ["unsafe_pub", "titan"] }
+#drift-rs = { path = "../drift-rs", features = ["unsafe_pub", "titan"] }
 env_logger = "0.11"
 # DLOB 'trace' logs are expensive so compile them out
 log = { version = "0.4", features = ["max_level_trace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ axum = "0.8"
 clap = { version = "4.5.40", "features" = ["env", "derive"] }
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 dotenv = "0.15.0"
-drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "17f57b7", features = ["unsafe_pub", "titan"] }
+drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "d6b482c", features = ["unsafe_pub", "titan"] }
 env_logger = "0.11"
 # DLOB 'trace' logs are expensive so compile them out
 log = { version = "0.4", features = ["max_level_trace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ solana-sdk = "2.3"
 solana-transaction-status = "2.3"
 solana-transaction-status-client-types = "2.3"
 tokio = "1.48"
+dashmap = "6.1.0"
 
 [[bin]]
 name = "tx_history"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ axum = "0.8"
 clap = { version = "4.5.40", "features" = ["env", "derive"] }
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 dotenv = "0.15.0"
-drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "4463af2", features = ["unsafe_pub", "titan"] }
+drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "17f57b7", features = ["unsafe_pub", "titan"] }
 env_logger = "0.11"
 # DLOB 'trace' logs are expensive so compile them out
 log = { version = "0.4", features = ["max_level_trace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ axum = "0.8"
 clap = { version = "4.5.40", "features" = ["env", "derive"] }
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 dotenv = "0.15.0"
-drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "5590796", features = ["unsafe_pub", "titan"] }
+drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "4463af2", features = ["unsafe_pub", "titan"] }
 env_logger = "0.11"
 # DLOB 'trace' logs are expensive so compile them out
 log = { version = "0.4", features = ["max_level_trace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ axum = "0.8"
 clap = { version = "4.5.40", "features" = ["env", "derive"] }
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 dotenv = "0.15.0"
-drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "1321f1", features = ["unsafe_pub", "titan"] }
-#drift-rs = { path = "../drift-rs", features = ["unsafe_pub", "titan"] }
+drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "fac78b", features = ["unsafe_pub", "titan"] }
 env_logger = "0.11"
 # DLOB 'trace' logs are expensive so compile them out
 log = { version = "0.4", features = ["max_level_trace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ axum = "0.8"
 clap = { version = "4.5.40", "features" = ["env", "derive"] }
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 dotenv = "0.15.0"
-drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "45528b", features = ["unsafe_pub", "titan"] }
+drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "1689419", features = ["unsafe_pub", "titan"] }
 env_logger = "0.11"
 # DLOB 'trace' logs are expensive so compile them out
 log = { version = "0.4", features = ["max_level_trace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ axum = "0.8"
 clap = { version = "4.5.40", "features" = ["env", "derive"] }
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 dotenv = "0.15.0"
-drift-rs = { git = "https://github.com/drift-labs/drift-rs", branch = "trunk/isolated-positions", features = ["unsafe_pub", "titan"] }
+drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "1689419", features = ["unsafe_pub", "titan"] }
 env_logger = "0.11"
 # DLOB 'trace' logs are expensive so compile them out
 log = { version = "0.4", features = ["max_level_trace"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,10 @@ RUN cargo build --release
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y ca-certificates lldb
 COPY --from=builder /usr/local/lib/libdrift_ffi_sys.so /lib/
-COPY --from=builder /app/target/release/keeprs /usr/local/bin/keeprs
+COPY --from=builder /app/target/release/keeprs /usr/local/bin/keeprs-real
+
+RUN echo '#!/bin/bash\nexec lldb -o "run" -o "bt all" -o "quit" -- /usr/local/bin/keeprs-real "$@"' > /usr/local/bin/keeprs && \
+    chmod +x /usr/local/bin/keeprs
 
 EXPOSE 9898
 ENV METRICS_PORT=9898
-
-ENTRYPOINT ["lldb", "-o", "run", "-o", "bt", "-o", "quit", "--", "/usr/local/bin/keeprs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,16 @@ RUN cargo build --release
 
 # ---- Runtime Stage ----
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y ca-certificates lldb
+# RUN apt-get update && apt-get install -y ca-certificates lldb
+RUN apt-get update && apt-get install -y ca-certificates
 COPY --from=builder /usr/local/lib/libdrift_ffi_sys.so /lib/
-COPY --from=builder /app/target/release/keeprs /usr/local/bin/keeprs-real
+# COPY --from=builder /app/target/release/keeprs /usr/local/bin/keeprs-real
+COPY --from=builder /app/target/release/keeprs /usr/local/bin/keeprs
 
-RUN echo '#!/bin/bash\nexec lldb -o "run" -o "bt all" -o "quit" -- /usr/local/bin/keeprs-real "$@"' > /usr/local/bin/keeprs && \
-    chmod +x /usr/local/bin/keeprs
+# RUN echo '#!/bin/bash\nexec lldb -o "run" -o "bt all" -o "quit" -- /usr/local/bin/keeprs-real "$@"' > /usr/local/bin/keeprs && \
+#     chmod +x /usr/local/bin/keeprs
 
 EXPOSE 9898
 ENV METRICS_PORT=9898
+
+ENTRYPOINT ["/usr/local/bin/keeprs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && apt-get install jq -y && rustup component add rustfmt
 
 # install libdrift
 RUN SO_URL=$(curl -s https://api.github.com/repos/drift-labs/drift-ffi-sys/releases/latest | jq -r '.assets[] | select(.name=="libdrift_ffi_sys.so") | .browser_download_url') &&\
-  curl -L -o libdrift_ffi_sys.so "$SO_URL" &&\
-  cp libdrift_ffi_sys.so $CARGO_DRIFT_FFI_PATH
+    curl -L -o libdrift_ffi_sys.so "$SO_URL" &&\
+    cp libdrift_ffi_sys.so $CARGO_DRIFT_FFI_PATH
 
 # 2. Copy actual code and rebuild
 # TODO: docker layer cache
@@ -24,11 +24,11 @@ RUN cargo build --release
 
 # ---- Runtime Stage ----
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get update && apt-get install -y ca-certificates lldb
 COPY --from=builder /usr/local/lib/libdrift_ffi_sys.so /lib/
 COPY --from=builder /app/target/release/keeprs /usr/local/bin/keeprs
 
 EXPOSE 9898
 ENV METRICS_PORT=9898
 
-ENTRYPOINT ["./keeprs"] 
+ENTRYPOINT ["lldb", "-o", "run", "-o", "bt", "-o", "quit", "--", "/usr/local/bin/keeprs"]

--- a/src/filler.rs
+++ b/src/filler.rs
@@ -1069,7 +1069,7 @@ impl TxWorker {
             match drift.simulate_tx(tx.clone()).await {
                 Ok(sim_result) => {
                     if let Some(err) = sim_result.err {
-                        log::debug!(target: TARGET, "sim failed: {err:?}, intent: {intent_label}");
+                        log::warn!(target: TARGET, "sim failed: {err:?}, intent: {intent_label}");
                         metrics
                             .tx_failed
                             .with_label_values(&[intent_label, "sim_failed"])

--- a/src/filler.rs
+++ b/src/filler.rs
@@ -15,7 +15,10 @@ use drift_rs::{
     },
     event_subscriber::DriftEvent,
     ffi::calculate_auction_price,
-    grpc::{grpc_subscriber::AccountFilter, AccountUpdate, TransactionUpdate},
+    grpc::{
+        grpc_subscriber::{AccountFilter, GrpcConnectionOpts},
+        AccountUpdate, TransactionUpdate,
+    },
     priority_fee_subscriber::PriorityFeeSubscriber,
     swift_order_subscriber::{SignedOrderInfo, SwiftOrderStream},
     types::{
@@ -169,12 +172,18 @@ impl FillerBot {
         let (_dummy_tx, dummy_rx) = tokio::sync::mpsc::channel::<PythPriceUpdate>(1);
         let mut pyth_price_feed = self.pyth_price_feed.unwrap_or(dummy_rx);
 
+        // Swift retry mechanism
+        const MAX_SWIFT_RECONNECT_RETRIES: u32 = 10;
+        let mut retries = 0u32;
         loop {
             tokio::select! {
                 biased;
                 swift_order = swift_order_stream.next() => {
                     match swift_order {
                         Some(signed_order) => {
+                            // reset
+                            retries = 0;
+
                             // try swift fill against resting liquidity
                             let mut order_params = signed_order.order_params();
                             log::info!(target: TARGET, "new swift order. uuid={}, market={}", signed_order.order_uuid_str(), order_params.market_index);
@@ -263,8 +272,26 @@ impl FillerBot {
                             }
                         }
                         None => {
-                            log::error!(target: TARGET, "swift order stream finished");
-                            break;
+                            retries += 1;
+                            if retries <= MAX_SWIFT_RECONNECT_RETRIES {
+                                    let backoff = 2u64.pow(retries).min(30);
+                                    log::warn!(target: "swift", "feed disconnected, retry {retries}/{MAX_SWIFT_RECONNECT_RETRIES} in {backoff}s");
+                                    tokio::time::sleep(Duration::from_secs(backoff)).await;
+
+                                    match drift
+                                        .subscribe_swift_orders(&market_ids, Some(true), None, None)
+                                        .await
+                                    {
+                                        Ok(stream) => swift_order_stream = stream,
+                                        Err(e) => {
+                                            log::error!(target: "swift", "resubscribe failed: {e:?}");
+                                            continue;
+                                        }
+                                    }
+                                } else {
+                                    log::error!(target: TARGET, "swift order stream finished after {MAX_SWIFT_RECONNECT_RETRIES} retries");
+                                    break;
+                                }
                         }
                     }
                 }
@@ -984,6 +1011,7 @@ async fn subscribe_grpc(
             std::env::var("GRPC_X_TOKEN").expect("GRPC_X_TOKEN set"),
             GrpcSubscribeOpts::default()
                 .commitment(solana_sdk::commitment_config::CommitmentLevel::Processed)
+                .connection_opts(GrpcConnectionOpts::default().enable_compression())
                 .usermap_on()
                 .statsmap_on()
                 .transaction_include_accounts(vec![drift.wallet().default_sub_account()])
@@ -1098,7 +1126,7 @@ impl TxWorker {
 
         rt.spawn(async move {
             // simulate first
-            match drift.simulate_tx(signed_tx.message.clone()).await {
+            match drift.simulate_tx(tx.clone()).await {
                 Ok(sim_result) => {
                     if let Some(err) = sim_result.err {
                         log::warn!(target: TARGET, "sim failed: {err:?}, intent: {intent_label}");
@@ -1118,12 +1146,6 @@ impl TxWorker {
                     return;
                 }
             }
-
-            let config = RpcSendTransactionConfig {
-                skip_preflight: true,
-                max_retries: Some(0),
-                ..Default::default()
-            };
 
             match drift
                 .rpc()

--- a/src/filler.rs
+++ b/src/filler.rs
@@ -901,6 +901,7 @@ pub async fn sync_stats_accounts(
                     rent_epoch: u64::MAX,
                     executable: false,
                     slot: 0,
+                    write_version: 0,
                 });
             }
             log::info!(target: "dlob", "syncd stats accounts");
@@ -948,6 +949,7 @@ pub async fn sync_user_accounts(
                     rent_epoch: u64::MAX,
                     executable: false,
                     slot: 0,
+                    write_version: 0,
                 });
             }
             log::info!(target: "dlob", "synced initial orders");

--- a/src/filler.rs
+++ b/src/filler.rs
@@ -18,8 +18,8 @@ use drift_rs::{
     priority_fee_subscriber::PriorityFeeSubscriber,
     swift_order_subscriber::{SignedOrderInfo, SwiftOrderStream},
     types::{
-        accounts::{User, UserStats},
-        CommitmentConfig, MarketId, MarketPrecision, MarketStatus, MarketType, Order,
+        accounts::{PerpMarket, User, UserStats},
+        CommitmentConfig, FeeTier, MarketId, MarketPrecision, MarketStatus, MarketType, Order,
         OrderTriggerCondition, OrderType, PositionDirection, PostOnlyParam,
         RpcSendTransactionConfig, VersionedMessage, AMM,
     },
@@ -264,7 +264,12 @@ impl FillerBot {
                     }
                 }
                 new_slot = slot_rx.recv() => {
+                    if new_slot.is_none() {
+                        log::error!(target: TARGET, "slot subscriber failed");
+                        break;
+                    }
                     slot = new_slot.expect("got slot update");
+                    log::trace!(target: TARGET, "got slot update: {slot}");
 
                     let priority_fee = priority_fee_subscriber.priority_fee_nth(0.5) + slot % 2; // add entropy to produce unique tx hash on conseuctive tx resubmission
                     let t0 = std::time::SystemTime::now();
@@ -305,6 +310,7 @@ impl FillerBot {
                                 move |maker_cross| {
                                     perp_market.has_too_much_drawdown() && amm_wants_to_jit_make(&perp_market.amm, maker_cross.taker_direction)
                                 },
+                                perp_market,
                             ).await;
                         }
 
@@ -370,7 +376,9 @@ fn on_slot_update_fn(
                 .unwrap();
             dlob_notifier.slot_and_oracle_update(*market, new_slot, oracle_price_data.price as u64);
         }
-        slot_tx.try_send(new_slot).expect("sent");
+        if let Err(err) = slot_tx.try_send(new_slot) {
+            log::debug!(target: TARGET, "failed slot update: {err:?}");
+        }
     }
 }
 
@@ -500,6 +508,7 @@ async fn try_auction_fill(
     oracle_update: Option<PythPriceUpdate>,
     trigger_price: u64,
     is_vamm_inactive: impl Fn(&MakerCrosses) -> bool,
+    perp_market: PerpMarket,
 ) {
     let filler_account_data = drift
         .try_get_account::<User>(&filler_subaccount)
@@ -611,9 +620,41 @@ async fn try_auction_fill(
             })
             .collect();
 
-        if crosses.has_vamm_cross && is_vamm_inactive(&crosses) {
-            log::debug!(target: TARGET, "skip inactive vamm cross: {crosses:?}");
-            return;
+        if crosses.has_vamm_cross {
+            if is_vamm_inactive(&crosses) {
+                log::debug!(target: TARGET, "skip inactive vamm cross: {crosses:?}");
+                return;
+            }
+
+            if let Ok(pos) = taker_account_data.get_perp_position(market_index) {
+                if let Ok((base_asset_amount, _limit_price)) = perp_market
+                    .calculate_base_asset_amount_for_amm_to_fulfill(
+                        &taker_account_data
+                            .orders
+                            .iter()
+                            .find(|o| o.order_id == taker_order.order_id)
+                            .unwrap(),
+                        &perp_market,
+                        None,
+                        None,
+                        pos.base_asset_amount,
+                        &FeeTier::default(),
+                    )
+                {
+                    // if user position is less than min order size, step size is the threshold
+                    let amm_size_threshold = if !taker_order.is_reduce_only()
+                        && pos.base_asset_amount.unsigned_abs() > perp_market.amm.min_order_size
+                    {
+                        perp_market.amm.min_order_size
+                    } else {
+                        perp_market.amm.order_step_size
+                    };
+                    if base_asset_amount < amm_size_threshold {
+                        log::info!(target: TARGET, "skip vamm cross too small: {crosses:?}");
+                        return;
+                    }
+                }
+            }
         }
         if !crosses.has_vamm_cross && maker_accounts.is_empty() {
             log::debug!(target: TARGET, "skip empty maker cross: {crosses:?}");

--- a/src/filler.rs
+++ b/src/filler.rs
@@ -14,7 +14,10 @@ use drift_rs::{
     },
     event_subscriber::DriftEvent,
     ffi::calculate_auction_price,
-    grpc::{grpc_subscriber::AccountFilter, AccountUpdate, TransactionUpdate},
+    grpc::{
+        grpc_subscriber::{AccountFilter, GrpcConnectionOpts},
+        AccountUpdate, TransactionUpdate,
+    },
     priority_fee_subscriber::PriorityFeeSubscriber,
     swift_order_subscriber::{SignedOrderInfo, SwiftOrderStream},
     types::{
@@ -1001,6 +1004,7 @@ async fn subscribe_grpc(
             std::env::var("GRPC_X_TOKEN").expect("GRPC_X_TOKEN set"),
             GrpcSubscribeOpts::default()
                 .commitment(solana_sdk::commitment_config::CommitmentLevel::Processed)
+                .connection_opts(GrpcConnectionOpts::default().enable_compression())
                 .usermap_on()
                 .statsmap_on()
                 .transaction_include_accounts(vec![drift.wallet().default_sub_account()])

--- a/src/filler.rs
+++ b/src/filler.rs
@@ -18,8 +18,8 @@ use drift_rs::{
     priority_fee_subscriber::PriorityFeeSubscriber,
     swift_order_subscriber::{SignedOrderInfo, SwiftOrderStream},
     types::{
-        accounts::{User, UserStats},
-        CommitmentConfig, MarketId, MarketPrecision, MarketStatus, MarketType, Order,
+        accounts::{PerpMarket, User, UserStats},
+        CommitmentConfig, FeeTier, MarketId, MarketPrecision, MarketStatus, MarketType, Order,
         OrderTriggerCondition, OrderType, PositionDirection, PostOnlyParam,
         RpcSendTransactionConfig, VersionedMessage, AMM,
     },
@@ -187,7 +187,11 @@ impl FillerBot {
                                 oracle_price,
                                 true,
                             );
-                            log::debug!("updated order params");
+                            if order_params.order_type == OrderType::Limit && order_params.post_only != PostOnlyParam::None {
+                                log::warn!(target: TARGET, "swift order limit post only: {signed_order:?}");
+                                // TODO: search for immediate fill
+                                continue;
+                            }
                             let (start_price, end_price, duration) = (order_params.auction_start_price.unwrap_or_default(), order_params.auction_end_price.unwrap_or_default(), order_params.auction_duration.unwrap_or_default());
                             let order = Order {
                                 slot: slot + 1,
@@ -264,7 +268,12 @@ impl FillerBot {
                     }
                 }
                 new_slot = slot_rx.recv() => {
+                    if new_slot.is_none() {
+                        log::error!(target: TARGET, "slot subscriber failed");
+                        break;
+                    }
                     slot = new_slot.expect("got slot update");
+                    log::trace!(target: TARGET, "got slot update: {slot}");
 
                     let priority_fee = priority_fee_subscriber.priority_fee_nth(0.5) + slot % 2; // add entropy to produce unique tx hash on conseuctive tx resubmission
                     let t0 = std::time::SystemTime::now();
@@ -287,7 +296,7 @@ impl FillerBot {
                             }
                         }
 
-                        let mut crosses_and_top_makers = dlob.find_crosses_for_auctions(market_index, MarketType::Perp, slot, oracle_price, Some(&perp_market), None);
+                        let mut crosses_and_top_makers = dlob.find_crosses_for_auctions(market_index, MarketType::Perp, slot, oracle_price, Some(&perp_market), trigger_price, None);
                         crosses_and_top_makers.crosses.retain(|(o, _)| limiter.allow_event(slot, o.order_id));
 
                         if !crosses_and_top_makers.crosses.is_empty() {
@@ -305,13 +314,14 @@ impl FillerBot {
                                 move |maker_cross| {
                                     perp_market.has_too_much_drawdown() && amm_wants_to_jit_make(&perp_market.amm, maker_cross.taker_direction)
                                 },
+                                perp_market,
                             ).await;
                         }
 
                         // ghetto rate limit
                         if slot % 2 == 0 {
                             if let Some(crosses) = dlob.find_crossing_region(oracle_price, market_index, MarketType::Perp, Some(&perp_market)) {
-                                log::info!(target: TARGET, "found limit crosses (market: {market_index}), top bid: {:?}, top ask: {:?}", crosses.crossing_asks.first(), crosses.crossing_bids.first());
+                                log::info!(target: TARGET, "found limit crosses (market: {market_index}), top bid: {:?}, top ask: {:?}", crosses.crossing_bids.first(), crosses.crossing_asks.first());
                                 try_uncross(drift, slot + 1, priority_fee, config.fill_cu_limit, market_index, filler_subaccount, crosses, &tx_worker_ref);
                             }
                         }
@@ -370,7 +380,9 @@ fn on_slot_update_fn(
                 .unwrap();
             dlob_notifier.slot_and_oracle_update(*market, new_slot, oracle_price_data.price as u64);
         }
-        slot_tx.try_send(new_slot).expect("sent");
+        if let Err(err) = slot_tx.try_send(new_slot) {
+            log::debug!(target: TARGET, "failed slot update: {err:?}");
+        }
     }
 }
 
@@ -500,6 +512,7 @@ async fn try_auction_fill(
     oracle_update: Option<PythPriceUpdate>,
     trigger_price: u64,
     is_vamm_inactive: impl Fn(&MakerCrosses) -> bool,
+    perp_market: PerpMarket,
 ) {
     let filler_account_data = drift
         .try_get_account::<User>(&filler_subaccount)
@@ -611,9 +624,41 @@ async fn try_auction_fill(
             })
             .collect();
 
-        if crosses.has_vamm_cross && is_vamm_inactive(&crosses) {
-            log::debug!(target: TARGET, "skip inactive vamm cross: {crosses:?}");
-            return;
+        if crosses.has_vamm_cross {
+            if is_vamm_inactive(&crosses) {
+                log::debug!(target: TARGET, "skip inactive vamm cross: {crosses:?}");
+                return;
+            }
+
+            if let Ok(pos) = taker_account_data.get_perp_position(market_index) {
+                if let Ok((base_asset_amount, _limit_price)) = perp_market
+                    .calculate_base_asset_amount_for_amm_to_fulfill(
+                        &taker_account_data
+                            .orders
+                            .iter()
+                            .find(|o| o.order_id == taker_order.order_id)
+                            .unwrap(),
+                        &perp_market,
+                        None,
+                        None,
+                        pos.base_asset_amount,
+                        &FeeTier::default(),
+                    )
+                {
+                    // if user position is less than min order size, step size is the threshold
+                    let amm_size_threshold = if !taker_order.is_reduce_only()
+                        && pos.base_asset_amount.unsigned_abs() > perp_market.amm.min_order_size
+                    {
+                        perp_market.amm.min_order_size
+                    } else {
+                        perp_market.amm.order_step_size
+                    };
+                    if base_asset_amount < amm_size_threshold {
+                        log::info!(target: TARGET, "skip vamm cross too small: {crosses:?}");
+                        return;
+                    }
+                }
+            }
         }
         if !crosses.has_vamm_cross && maker_accounts.is_empty() {
             log::debug!(target: TARGET, "skip empty maker cross: {crosses:?}");
@@ -692,7 +737,7 @@ fn try_uncross(
     let maker_asks: Vec<User> = crosses
         .crossing_asks
         .iter()
-        .take(5)
+        .take(3)
         .filter_map(|x| {
             let maker = x.user;
             if maker != best_bid.user {
@@ -706,7 +751,7 @@ fn try_uncross(
     let maker_bids: Vec<User> = crosses
         .crossing_bids
         .iter()
-        .take(5)
+        .take(3)
         .filter_map(|x| {
             let maker = x.user;
             if maker != best_ask.user {
@@ -718,16 +763,21 @@ fn try_uncross(
         .collect();
 
     log::info!(target: TARGET, "try uncross book={market_index},slot={slot}");
-    log::info!(
+    log::debug!(
         target: TARGET,
         "X asks: {:?}, X bids: {:?}",
-        crosses.crossing_asks,
-        crosses.crossing_bids
+        &crosses.crossing_asks.iter().take(3),
+        &crosses.crossing_bids.iter().take(3),
     );
 
     // try valid combinations of taker/maker with all crossing asks/bids
     for (taker_order, makers) in [(best_ask, maker_bids), (best_bid, maker_asks)] {
         if taker_order.is_post_only() {
+            continue;
+        }
+
+        if makers.is_empty() {
+            log::debug!(target: TARGET, "no makers to uncross");
             continue;
         }
 

--- a/src/filler.rs
+++ b/src/filler.rs
@@ -1065,6 +1065,28 @@ impl TxWorker {
         }
 
         rt.spawn(async move {
+            // simulate first
+            match drift.simulate_tx(tx.clone()).await {
+                Ok(sim_result) => {
+                    if let Some(err) = sim_result.err {
+                        log::debug!(target: TARGET, "sim failed: {err:?}, intent: {intent_label}");
+                        metrics
+                            .tx_failed
+                            .with_label_values(&[intent_label, "sim_failed"])
+                            .inc();
+                        return;
+                    }
+                }
+                Err(err) => {
+                    log::warn!(target: TARGET, "sim rpc error: {err}, skipping tx");
+                    metrics
+                        .tx_failed
+                        .with_label_values(&[intent_label, "sim_rpc_error"])
+                        .inc();
+                    return;
+                }
+            }
+
             match drift
                 .sign_and_send_with_config(
                     tx,

--- a/src/filler.rs
+++ b/src/filler.rs
@@ -1,11 +1,12 @@
 //! Filler Bot
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use anchor_lang::Discriminator;
+use dashmap::DashMap;
 use drift_rs::{
     constants::PROGRAM_ID,
     dlob::{
@@ -21,7 +22,7 @@ use drift_rs::{
         accounts::{PerpMarket, User, UserStats},
         CommitmentConfig, FeatureBitFlags, FeeTier, MarketId, MarketPrecision, MarketStatus,
         MarketType, Order, OrderTriggerCondition, OrderType, PositionDirection, PostOnlyParam,
-        RpcSendTransactionConfig, VersionedMessage, AMM,
+        RpcSendTransactionConfig, VersionedMessage, VersionedTransaction, AMM,
     },
     DriftClient, GrpcSubscribeOpts, Pubkey, TransactionBuilder, Wallet,
 };
@@ -61,7 +62,7 @@ pub struct FillerBot {
 impl FillerBot {
     pub async fn new(config: Config, drift: DriftClient, metrics: Arc<Metrics>) -> Self {
         let dlob: &'static DLOB = Box::leak(Box::new(DLOB::default()));
-        let tx_worker = TxWorker::new(drift.clone(), metrics, config.dry);
+        let tx_worker = TxWorker::new(drift.clone(), metrics, config.dry, None, None, None);
         let rt = tokio::runtime::Handle::current();
         let tx_worker_ref = tx_worker.run(rt);
 
@@ -322,7 +323,7 @@ impl FillerBot {
                         if slot % 2 == 0 {
                             if let Some(crosses) = dlob.find_crossing_region(oracle_price, market_index, MarketType::Perp, Some(&perp_market)) {
                                 log::info!(target: TARGET, "found limit crosses (market: {market_index}), top bid: {:?}, top ask: {:?}", crosses.crossing_bids.first(), crosses.crossing_asks.first());
-                                try_uncross(drift, slot + 1, priority_fee, config.fill_cu_limit, market_index, filler_subaccount, crosses, &tx_worker_ref);
+                                try_uncross(drift, slot + 1, priority_fee, config.fill_cu_limit, market_index, filler_subaccount, crosses, &tx_worker_ref).await;
                             }
                         }
 
@@ -489,13 +490,15 @@ async fn try_swift_fill(
     }
     let tx = tx_builder.build();
 
-    tx_worker_ref.send_tx(
-        tx,
-        TxIntent::SwiftFill {
-            maker_crosses: crosses,
-        },
-        cu_limit as u64,
-    );
+    tx_worker_ref
+        .send_tx(
+            tx,
+            TxIntent::SwiftFill {
+                maker_crosses: crosses,
+            },
+            cu_limit as u64,
+        )
+        .await;
 }
 
 /// Try to fill an auction order
@@ -695,22 +698,24 @@ async fn try_auction_fill(
 
         let tx = tx_builder.build();
 
-        tx_worker_ref.send_tx(
-            tx,
-            TxIntent::AuctionFill {
-                taker_order_id: taker_order.order_id,
-                maker_crosses: crosses,
-                has_trigger: taker_is_trigger,
-            },
-            cu_limit as u64,
-        );
+        tx_worker_ref
+            .send_tx(
+                tx,
+                TxIntent::AuctionFill {
+                    taker_order_id: taker_order.order_id,
+                    maker_crosses: crosses,
+                    has_trigger: taker_is_trigger,
+                },
+                cu_limit as u64,
+            )
+            .await;
     }
 }
 
 /// Try to uncross top of book
 ///
 /// - `crosses` list of one or more crosses to fill
-fn try_uncross(
+async fn try_uncross(
     drift: &DriftClient,
     slot: u64,
     priority_fee: u64,
@@ -824,16 +829,18 @@ fn try_uncross(
         }
         let tx = tx_builder.build();
 
-        tx_worker_ref.send_tx(
-            tx,
-            TxIntent::LimitUncross {
-                slot,
-                market_index,
-                taker_order_id,
-                maker_order_id: 0,
-            },
-            cu_limit as u64,
-        );
+        tx_worker_ref
+            .send_tx(
+                tx,
+                TxIntent::LimitUncross {
+                    slot,
+                    market_index,
+                    taker_order_id,
+                    maker_order_id: 0,
+                },
+                cu_limit as u64,
+            )
+            .await;
     }
 }
 
@@ -998,7 +1005,7 @@ async fn subscribe_grpc(
 
 pub enum TxWork {
     Send {
-        tx: VersionedMessage,
+        tx: VersionedTransaction,
         ts: u64,
         intent: TxIntent,
         cu_limit: u64,
@@ -1014,19 +1021,34 @@ pub struct TxWorker {
     pending_txs: Arc<RwLock<PendingTxs<1024>>>,
     metrics: Arc<Metrics>,
     dry_run: bool,
+    txs_in_flight: Option<Arc<DashMap<Pubkey, HashSet<Signature>>>>,
+    tx_sig_to_collateral: Option<Arc<DashMap<Signature, u128>>>,
+    free_collateral_per_subaccount: Option<Arc<DashMap<Pubkey, u128>>>,
 }
 
 impl TxWorker {
-    pub fn new(drift: DriftClient, metrics: Arc<Metrics>, dry_run: bool) -> Self {
+    pub fn new(
+        drift: DriftClient,
+        metrics: Arc<Metrics>,
+        dry_run: bool,
+        txs_in_flight: Option<Arc<DashMap<Pubkey, HashSet<Signature>>>>,
+        tx_sig_to_collateral: Option<Arc<DashMap<Signature, u128>>>,
+        free_collateral_per_subaccount: Option<Arc<DashMap<Pubkey, u128>>>,
+    ) -> Self {
         Self {
             drift: Box::leak(Box::new(drift)),
             pending_txs: Arc::new(RwLock::new(PendingTxs::new())),
             metrics,
             dry_run,
+            txs_in_flight,
+            tx_sig_to_collateral,
+            free_collateral_per_subaccount,
         }
     }
+
     pub fn run(self, rt: tokio::runtime::Handle) -> TxSender {
         let (tx, rx) = crossbeam::channel::bounded(1024);
+        let drift = self.drift;
         std::thread::spawn(move || {
             let _ = env_logger::try_init();
             while let Ok(work) = rx.recv() {
@@ -1049,14 +1071,22 @@ impl TxWorker {
                 }
             }
         });
-        TxSender(tx)
+        TxSender { tx, drift }
     }
-    fn send_tx(&self, rt: &Handle, tx: VersionedMessage, intent: TxIntent, cu_limit: u64) {
+
+    fn send_tx(
+        &self,
+        rt: &Handle,
+        signed_tx: VersionedTransaction,
+        intent: TxIntent,
+        cu_limit: u64,
+    ) {
         log::debug!(target: TARGET, "txworker send tx: {intent:?}");
         let drift = self.drift;
         let pending_txs = Arc::clone(&self.pending_txs);
         let metrics = self.metrics.clone();
         let intent_label = intent.label();
+
         metrics.tx_sent.with_label_values(&[intent_label]).inc();
         metrics
             .fill_expected
@@ -1067,16 +1097,37 @@ impl TxWorker {
         }
 
         rt.spawn(async move {
+            // simulate first
+            match drift.simulate_tx(signed_tx.message.clone()).await {
+                Ok(sim_result) => {
+                    if let Some(err) = sim_result.err {
+                        log::warn!(target: TARGET, "sim failed: {err:?}, intent: {intent_label}");
+                        metrics
+                            .tx_failed
+                            .with_label_values(&[intent_label, "sim_failed"])
+                            .inc();
+                        return;
+                    }
+                }
+                Err(err) => {
+                    log::warn!(target: TARGET, "sim rpc error: {err}, skipping tx");
+                    metrics
+                        .tx_failed
+                        .with_label_values(&[intent_label, "sim_rpc_error"])
+                        .inc();
+                    return;
+                }
+            }
+
+            let config = RpcSendTransactionConfig {
+                skip_preflight: true,
+                max_retries: Some(0),
+                ..Default::default()
+            };
+
             match drift
-                .sign_and_send_with_config(
-                    tx,
-                    None,
-                    RpcSendTransactionConfig {
-                        skip_preflight: true,
-                        max_retries: Some(0),
-                        ..Default::default()
-                    },
-                )
+                .rpc()
+                .send_transaction_with_config(&signed_tx, config)
                 .await
             {
                 Ok(sig) => {
@@ -1100,12 +1151,18 @@ impl TxWorker {
             }
         });
     }
+
     fn confirm_tx(&self, rt: &Handle, tx: Signature) {
         // TODO: if CU limit is too low send it again with higher amount
         log::debug!(target: TARGET, "txworker confirm tx: {tx:?}");
         let drift = self.drift;
         let pending_txs = Arc::clone(&self.pending_txs);
         let metrics = self.metrics.clone();
+
+        let txs_in_flight = self.txs_in_flight.clone();
+        let tx_sig_to_collateral = self.tx_sig_to_collateral.clone();
+        let free_collateral = self.free_collateral_per_subaccount.clone();
+
         rt.spawn(async move {
             let pending_tx_meta = {
                 let mut pending = pending_txs.write().await;
@@ -1115,11 +1172,12 @@ impl TxWorker {
                 return;
             }
             let PendingTxMeta {
-                signature: _,
+                signature,
                 intent,
                 cu_limit: sent_cu_limit,
                 ts: _,
             } = pending_tx_meta.unwrap();
+
             let intent_label = intent.label();
             let expected_fill_count = intent.expected_fill_count();
             let _ = tokio::time::sleep(Duration::from_secs(1)).await;
@@ -1261,16 +1319,34 @@ impl TxWorker {
                         .inc();
                 }
             }
+
+            if let (Some(tx_sig_map), Some(txs_map), Some(free_map)) =
+                (&tx_sig_to_collateral, &txs_in_flight, &free_collateral)
+            {
+                if let Some((_, collateral)) = tx_sig_map.remove(&signature) {
+                    for mut entry in txs_map.iter_mut() {
+                        if entry.value_mut().remove(&signature) {
+                            if let Some(mut free) = free_map.get_mut(entry.key()) {
+                                *free = free.saturating_add(collateral);
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
         });
     }
 }
 
 #[derive(Clone)]
-pub struct TxSender(crossbeam::channel::Sender<TxWork>);
+pub struct TxSender {
+    tx: crossbeam::channel::Sender<TxWork>,
+    drift: &'static DriftClient,
+}
 
 impl TxSender {
     pub fn confirm_tx(&self, tx: Signature) {
-        self.0
+        self.tx
             .send(TxWork::Confirm {
                 tx,
                 ts: SystemTime::now()
@@ -1280,10 +1356,20 @@ impl TxSender {
             })
             .expect("sent");
     }
-    pub fn send_tx(&self, tx: VersionedMessage, intent: TxIntent, cu_limit: u64) {
-        self.0
+
+    pub async fn send_tx(
+        &self,
+        tx: VersionedMessage,
+        intent: TxIntent,
+        cu_limit: u64,
+    ) -> Option<Signature> {
+        let blockhash = self.drift.get_latest_blockhash().await.unwrap();
+        let signed_tx = self.drift.wallet().sign_tx(tx, blockhash).ok()?;
+        let sig = signed_tx.signatures[0];
+
+        self.tx
             .send(TxWork::Send {
-                tx,
+                tx: signed_tx,
                 ts: SystemTime::now()
                     .duration_since(UNIX_EPOCH)
                     .unwrap()
@@ -1291,6 +1377,8 @@ impl TxSender {
                 intent,
                 cu_limit,
             })
-            .expect("sent");
+            .ok()?;
+
+        Some(sig)
     }
 }

--- a/src/filler.rs
+++ b/src/filler.rs
@@ -1126,7 +1126,7 @@ impl TxWorker {
 
         rt.spawn(async move {
             // simulate first
-            match drift.simulate_tx(tx.clone()).await {
+            match drift.simulate_tx(signed_tx.message.clone()).await {
                 Ok(sim_result) => {
                     if let Some(err) = sim_result.err {
                         log::warn!(target: TARGET, "sim failed: {err:?}, intent: {intent_label}");
@@ -1146,6 +1146,12 @@ impl TxWorker {
                     return;
                 }
             }
+
+            let config = RpcSendTransactionConfig {
+                skip_preflight: true,
+                max_retries: Some(0),
+                ..Default::default()
+            };
 
             match drift
                 .rpc()

--- a/src/filler.rs
+++ b/src/filler.rs
@@ -166,6 +166,10 @@ impl FillerBot {
             .state_account()
             .map(|s| s.has_median_trigger_price_feature())
             .unwrap_or(false);
+        let mut slots_before_stale_for_amm = drift
+            .state_account()
+            .map(|s| s.oracle_guard_rails.validity.slots_before_stale_for_amm)
+            .unwrap_or(10);
         let mut pyth_oracle_prices = BTreeMap::<u16, PythPriceUpdate>::new();
 
         // Create a dummy receiver that never sends when pyth is disabled
@@ -258,6 +262,13 @@ impl FillerBot {
                             let taker_order = TakerOrder::from_order_params(order_params, price);
                             let crosses = dlob.find_crosses_for_taker_order(slot + 1, oracle_price as u64, taker_order, Some(&perp_market), None);
                             if !crosses.is_empty() {
+                                // skip vAMM-only swift fills when oracle is stale
+                                if crosses.orders.is_empty() && crosses.has_vamm_cross {
+                                    if oracle_price_data.delay > slots_before_stale_for_amm {
+                                        log::info!(target: TARGET, "skip swift vAMM fill: oracle stale (delay={})", oracle_price_data.delay);
+                                        continue;
+                                    }
+                                }
                                 log::info!(target: TARGET, "found resting cross. crosses={crosses:?}");
                                 let pf = priority_fee_subscriber.priority_fee_nth(0.6);
                                 try_swift_fill(
@@ -314,6 +325,8 @@ impl FillerBot {
                         let perp_market = drift.try_get_perp_market_account(market_index).expect("got perp market");
                         let chain_oracle_data = drift.try_get_mmoracle_for_perp_market(market_index, slot).expect("got oracle price");
                         log::debug!(target: "oracle", "oracle price: delay:{:?},market:{:?},oracle:{:?},amm:{:?}", chain_oracle_data.delay, market, chain_oracle_data.price, perp_market.amm.mm_oracle_price);
+                        let oracle_stale_for_amm = chain_oracle_data.delay > slots_before_stale_for_amm;
+                        log::debug!(target: TARGET, "oracle_stale_for_amm={} (delay={}, market={})", oracle_stale_for_amm, chain_oracle_data.delay, market_index);
                         let mut oracle_price = chain_oracle_data.price as u64;
                         let trigger_price = perp_market.get_trigger_price(oracle_price as i64, unix_now, use_median_trigger_price).unwrap_or(oracle_price);
                         let mut pyth_update = None;
@@ -343,6 +356,7 @@ impl FillerBot {
                                     perp_market.has_too_much_drawdown() && amm_wants_to_jit_make(&perp_market.amm, maker_cross.taker_direction)
                                 },
                                 perp_market,
+                                oracle_stale_for_amm,
                             ).await;
                         }
 
@@ -357,9 +371,13 @@ impl FillerBot {
                         // check state config ~every minute
                         if slot % 300 == 0 {
                             use_median_trigger_price = drift
-                            .state_account()
-                            .map(|s| s.feature_bit_flags & FeatureBitFlags::MedianTriggerPrice as u8 != 0)
-                            .unwrap_or(false);
+                                .state_account()
+                                .map(|s| s.feature_bit_flags & FeatureBitFlags::MedianTriggerPrice as u8 != 0)
+                                .unwrap_or(false);
+                            slots_before_stale_for_amm = drift
+                                .state_account()
+                                .map(|s| s.oracle_guard_rails.validity.slots_before_stale_for_amm)
+                                .unwrap_or(10);
                         }
                     }
                     let duration = std::time::SystemTime::now().duration_since(t0).unwrap().as_millis();
@@ -543,6 +561,7 @@ async fn try_auction_fill(
     trigger_price: u64,
     is_vamm_inactive: impl Fn(&MakerCrosses) -> bool,
     perp_market: PerpMarket,
+    oracle_stale_for_amm: bool,
 ) {
     let filler_account_data = drift
         .try_get_account::<User>(&filler_subaccount)
@@ -654,7 +673,8 @@ async fn try_auction_fill(
             })
             .collect();
 
-        if crosses.has_vamm_cross {
+        let effective_vamm_cross = crosses.has_vamm_cross && !oracle_stale_for_amm;
+        if effective_vamm_cross {
             if is_vamm_inactive(&crosses) {
                 log::debug!(target: TARGET, "skip inactive vamm cross: {crosses:?}");
                 return;
@@ -690,8 +710,12 @@ async fn try_auction_fill(
                 }
             }
         }
-        if !crosses.has_vamm_cross && maker_accounts.is_empty() {
-            log::debug!(target: TARGET, "skip empty maker cross: {crosses:?}");
+        if !effective_vamm_cross && maker_accounts.is_empty() {
+            if oracle_stale_for_amm && crosses.has_vamm_cross {
+                log::info!(target: TARGET, "skip vAMM fill: oracle stale for AMM (market={market_index})");
+            } else {
+                log::debug!(target: TARGET, "skip empty maker cross: {crosses:?}");
+            }
             return;
         }
 

--- a/src/filler.rs
+++ b/src/filler.rs
@@ -19,8 +19,8 @@ use drift_rs::{
     swift_order_subscriber::{SignedOrderInfo, SwiftOrderStream},
     types::{
         accounts::{PerpMarket, User, UserStats},
-        CommitmentConfig, FeeTier, MarketId, MarketPrecision, MarketStatus, MarketType, Order,
-        OrderTriggerCondition, OrderType, PositionDirection, PostOnlyParam,
+        CommitmentConfig, FeatureBitFlags, FeeTier, MarketId, MarketPrecision, MarketStatus,
+        MarketType, Order, OrderTriggerCondition, OrderType, PositionDirection, PostOnlyParam,
         RpcSendTransactionConfig, VersionedMessage, AMM,
     },
     DriftClient, GrpcSubscribeOpts, Pubkey, TransactionBuilder, Wallet,
@@ -330,7 +330,7 @@ impl FillerBot {
                         if slot % 300 == 0 {
                             use_median_trigger_price = drift
                             .state_account()
-                            .map(|s| s.feature_bit_flags & 0b0000_0010 != 0) // FeatureBitFlags::MedianTriggerPrice
+                            .map(|s| s.feature_bit_flags & FeatureBitFlags::MedianTriggerPrice as u8 != 0)
                             .unwrap_or(false);
                         }
                     }

--- a/src/filler.rs
+++ b/src/filler.rs
@@ -187,7 +187,11 @@ impl FillerBot {
                                 oracle_price,
                                 true,
                             );
-                            log::debug!("updated order params");
+                            if order_params.order_type == OrderType::Limit && order_params.post_only != PostOnlyParam::None {
+                                log::warn!(target: TARGET, "swift order limit post only: {signed_order:?}");
+                                // TODO: search for immediate fill
+                                continue;
+                            }
                             let (start_price, end_price, duration) = (order_params.auction_start_price.unwrap_or_default(), order_params.auction_end_price.unwrap_or_default(), order_params.auction_duration.unwrap_or_default());
                             let order = Order {
                                 slot: slot + 1,
@@ -292,7 +296,7 @@ impl FillerBot {
                             }
                         }
 
-                        let mut crosses_and_top_makers = dlob.find_crosses_for_auctions(market_index, MarketType::Perp, slot, oracle_price, Some(&perp_market), None);
+                        let mut crosses_and_top_makers = dlob.find_crosses_for_auctions(market_index, MarketType::Perp, slot, oracle_price, Some(&perp_market), trigger_price, None);
                         crosses_and_top_makers.crosses.retain(|(o, _)| limiter.allow_event(slot, o.order_id));
 
                         if !crosses_and_top_makers.crosses.is_empty() {
@@ -759,11 +763,11 @@ fn try_uncross(
         .collect();
 
     log::info!(target: TARGET, "try uncross book={market_index},slot={slot}");
-    log::info!(
+    log::debug!(
         target: TARGET,
         "X asks: {:?}, X bids: {:?}",
-        crosses.crossing_asks,
-        crosses.crossing_bids,
+        &crosses.crossing_asks.iter().take(3),
+        &crosses.crossing_bids.iter().take(3),
     );
 
     // try valid combinations of taker/maker with all crossing asks/bids

--- a/src/filler.rs
+++ b/src/filler.rs
@@ -1,11 +1,12 @@
 //! Filler Bot
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use anchor_lang::Discriminator;
+use dashmap::DashMap;
 use drift_rs::{
     constants::PROGRAM_ID,
     dlob::{
@@ -24,7 +25,7 @@ use drift_rs::{
         accounts::{PerpMarket, User, UserStats},
         CommitmentConfig, FeatureBitFlags, FeeTier, MarketId, MarketPrecision, MarketStatus,
         MarketType, Order, OrderTriggerCondition, OrderType, PositionDirection, PostOnlyParam,
-        RpcSendTransactionConfig, VersionedMessage, AMM,
+        RpcSendTransactionConfig, VersionedMessage, VersionedTransaction, AMM,
     },
     DriftClient, GrpcSubscribeOpts, Pubkey, TransactionBuilder, Wallet,
 };
@@ -64,7 +65,7 @@ pub struct FillerBot {
 impl FillerBot {
     pub async fn new(config: Config, drift: DriftClient, metrics: Arc<Metrics>) -> Self {
         let dlob: &'static DLOB = Box::leak(Box::new(DLOB::default()));
-        let tx_worker = TxWorker::new(drift.clone(), metrics, config.dry);
+        let tx_worker = TxWorker::new(drift.clone(), metrics, config.dry, None, None, None);
         let rt = tokio::runtime::Handle::current();
         let tx_worker_ref = tx_worker.run(rt);
 
@@ -349,7 +350,7 @@ impl FillerBot {
                         if slot % 2 == 0 {
                             if let Some(crosses) = dlob.find_crossing_region(oracle_price, market_index, MarketType::Perp, Some(&perp_market)) {
                                 log::info!(target: TARGET, "found limit crosses (market: {market_index}), top bid: {:?}, top ask: {:?}", crosses.crossing_bids.first(), crosses.crossing_asks.first());
-                                try_uncross(drift, slot + 1, priority_fee, config.fill_cu_limit, market_index, filler_subaccount, crosses, &tx_worker_ref);
+                                try_uncross(drift, slot + 1, priority_fee, config.fill_cu_limit, market_index, filler_subaccount, crosses, &tx_worker_ref).await;
                             }
                         }
 
@@ -516,13 +517,15 @@ async fn try_swift_fill(
     }
     let tx = tx_builder.build();
 
-    tx_worker_ref.send_tx(
-        tx,
-        TxIntent::SwiftFill {
-            maker_crosses: crosses,
-        },
-        cu_limit as u64,
-    );
+    tx_worker_ref
+        .send_tx(
+            tx,
+            TxIntent::SwiftFill {
+                maker_crosses: crosses,
+            },
+            cu_limit as u64,
+        )
+        .await;
 }
 
 /// Try to fill an auction order
@@ -722,22 +725,24 @@ async fn try_auction_fill(
 
         let tx = tx_builder.build();
 
-        tx_worker_ref.send_tx(
-            tx,
-            TxIntent::AuctionFill {
-                taker_order_id: taker_order.order_id,
-                maker_crosses: crosses,
-                has_trigger: taker_is_trigger,
-            },
-            cu_limit as u64,
-        );
+        tx_worker_ref
+            .send_tx(
+                tx,
+                TxIntent::AuctionFill {
+                    taker_order_id: taker_order.order_id,
+                    maker_crosses: crosses,
+                    has_trigger: taker_is_trigger,
+                },
+                cu_limit as u64,
+            )
+            .await;
     }
 }
 
 /// Try to uncross top of book
 ///
 /// - `crosses` list of one or more crosses to fill
-fn try_uncross(
+async fn try_uncross(
     drift: &DriftClient,
     slot: u64,
     priority_fee: u64,
@@ -851,16 +856,18 @@ fn try_uncross(
         }
         let tx = tx_builder.build();
 
-        tx_worker_ref.send_tx(
-            tx,
-            TxIntent::LimitUncross {
-                slot,
-                market_index,
-                taker_order_id,
-                maker_order_id: 0,
-            },
-            cu_limit as u64,
-        );
+        tx_worker_ref
+            .send_tx(
+                tx,
+                TxIntent::LimitUncross {
+                    slot,
+                    market_index,
+                    taker_order_id,
+                    maker_order_id: 0,
+                },
+                cu_limit as u64,
+            )
+            .await;
     }
 }
 
@@ -1026,7 +1033,7 @@ async fn subscribe_grpc(
 
 pub enum TxWork {
     Send {
-        tx: VersionedMessage,
+        tx: VersionedTransaction,
         ts: u64,
         intent: TxIntent,
         cu_limit: u64,
@@ -1042,19 +1049,34 @@ pub struct TxWorker {
     pending_txs: Arc<RwLock<PendingTxs<1024>>>,
     metrics: Arc<Metrics>,
     dry_run: bool,
+    txs_in_flight: Option<Arc<DashMap<Pubkey, HashSet<Signature>>>>,
+    tx_sig_to_collateral: Option<Arc<DashMap<Signature, (u128, u64)>>>,
+    free_collateral_per_subaccount: Option<Arc<DashMap<Pubkey, u128>>>,
 }
 
 impl TxWorker {
-    pub fn new(drift: DriftClient, metrics: Arc<Metrics>, dry_run: bool) -> Self {
+    pub fn new(
+        drift: DriftClient,
+        metrics: Arc<Metrics>,
+        dry_run: bool,
+        txs_in_flight: Option<Arc<DashMap<Pubkey, HashSet<Signature>>>>,
+        tx_sig_to_collateral: Option<Arc<DashMap<Signature, (u128, u64)>>>,
+        free_collateral_per_subaccount: Option<Arc<DashMap<Pubkey, u128>>>,
+    ) -> Self {
         Self {
             drift: Box::leak(Box::new(drift)),
             pending_txs: Arc::new(RwLock::new(PendingTxs::new())),
             metrics,
             dry_run,
+            txs_in_flight,
+            tx_sig_to_collateral,
+            free_collateral_per_subaccount,
         }
     }
+
     pub fn run(self, rt: tokio::runtime::Handle) -> TxSender {
         let (tx, rx) = crossbeam::channel::bounded(1024);
+        let drift = self.drift;
         std::thread::spawn(move || {
             let _ = env_logger::try_init();
             while let Ok(work) = rx.recv() {
@@ -1077,14 +1099,22 @@ impl TxWorker {
                 }
             }
         });
-        TxSender(tx)
+        TxSender { tx, drift }
     }
-    fn send_tx(&self, rt: &Handle, tx: VersionedMessage, intent: TxIntent, cu_limit: u64) {
+
+    fn send_tx(
+        &self,
+        rt: &Handle,
+        signed_tx: VersionedTransaction,
+        intent: TxIntent,
+        cu_limit: u64,
+    ) {
         log::debug!(target: TARGET, "txworker send tx: {intent:?}");
         let drift = self.drift;
         let pending_txs = Arc::clone(&self.pending_txs);
         let metrics = self.metrics.clone();
         let intent_label = intent.label();
+
         metrics.tx_sent.with_label_values(&[intent_label]).inc();
         metrics
             .fill_expected
@@ -1096,7 +1126,7 @@ impl TxWorker {
 
         rt.spawn(async move {
             // simulate first
-            match drift.simulate_tx(tx.clone()).await {
+            match drift.simulate_tx(signed_tx.message.clone()).await {
                 Ok(sim_result) => {
                     if let Some(err) = sim_result.err {
                         log::warn!(target: TARGET, "sim failed: {err:?}, intent: {intent_label}");
@@ -1117,16 +1147,15 @@ impl TxWorker {
                 }
             }
 
+            let config = RpcSendTransactionConfig {
+                skip_preflight: true,
+                max_retries: Some(0),
+                ..Default::default()
+            };
+
             match drift
-                .sign_and_send_with_config(
-                    tx,
-                    None,
-                    RpcSendTransactionConfig {
-                        skip_preflight: true,
-                        max_retries: Some(0),
-                        ..Default::default()
-                    },
-                )
+                .rpc()
+                .send_transaction_with_config(&signed_tx, config)
                 .await
             {
                 Ok(sig) => {
@@ -1150,12 +1179,18 @@ impl TxWorker {
             }
         });
     }
+
     fn confirm_tx(&self, rt: &Handle, tx: Signature) {
         // TODO: if CU limit is too low send it again with higher amount
         log::debug!(target: TARGET, "txworker confirm tx: {tx:?}");
         let drift = self.drift;
         let pending_txs = Arc::clone(&self.pending_txs);
         let metrics = self.metrics.clone();
+
+        let txs_in_flight = self.txs_in_flight.clone();
+        let tx_sig_to_collateral = self.tx_sig_to_collateral.clone();
+        let free_collateral = self.free_collateral_per_subaccount.clone();
+
         rt.spawn(async move {
             let pending_tx_meta = {
                 let mut pending = pending_txs.write().await;
@@ -1165,11 +1200,12 @@ impl TxWorker {
                 return;
             }
             let PendingTxMeta {
-                signature: _,
+                signature,
                 intent,
                 cu_limit: sent_cu_limit,
                 ts: _,
             } = pending_tx_meta.unwrap();
+
             let intent_label = intent.label();
             let expected_fill_count = intent.expected_fill_count();
             let _ = tokio::time::sleep(Duration::from_secs(1)).await;
@@ -1293,6 +1329,21 @@ impl TxWorker {
                                     }
                                     _ => {}
                                 }
+
+                                if let (Some(tx_sig_map), Some(txs_map), Some(free_map)) =
+                                    (&tx_sig_to_collateral, &txs_in_flight, &free_collateral)
+                                {
+                                    if let Some((_sig, (collateral, _ts))) = tx_sig_map.remove(&signature) {
+                                        for mut entry in txs_map.iter_mut() {
+                                            if entry.value_mut().remove(&signature) {
+                                                if let Some(mut free) = free_map.get_mut(entry.key()) {
+                                                    *free = free.saturating_add(collateral);
+                                                }
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     } else {
@@ -1316,11 +1367,14 @@ impl TxWorker {
 }
 
 #[derive(Clone)]
-pub struct TxSender(crossbeam::channel::Sender<TxWork>);
+pub struct TxSender {
+    tx: crossbeam::channel::Sender<TxWork>,
+    drift: &'static DriftClient,
+}
 
 impl TxSender {
     pub fn confirm_tx(&self, tx: Signature) {
-        self.0
+        self.tx
             .send(TxWork::Confirm {
                 tx,
                 ts: SystemTime::now()
@@ -1330,10 +1384,20 @@ impl TxSender {
             })
             .expect("sent");
     }
-    pub fn send_tx(&self, tx: VersionedMessage, intent: TxIntent, cu_limit: u64) {
-        self.0
+
+    pub async fn send_tx(
+        &self,
+        tx: VersionedMessage,
+        intent: TxIntent,
+        cu_limit: u64,
+    ) -> Option<Signature> {
+        let blockhash = self.drift.get_latest_blockhash().await.unwrap();
+        let signed_tx = self.drift.wallet().sign_tx(tx, blockhash).ok()?;
+        let sig = signed_tx.signatures[0];
+
+        self.tx
             .send(TxWork::Send {
-                tx,
+                tx: signed_tx,
                 ts: SystemTime::now()
                     .duration_since(UNIX_EPOCH)
                     .unwrap()
@@ -1341,6 +1405,8 @@ impl TxSender {
                 intent,
                 cu_limit,
             })
-            .expect("sent");
+            .ok()?;
+
+        Some(sig)
     }
 }

--- a/src/filler.rs
+++ b/src/filler.rs
@@ -168,12 +168,18 @@ impl FillerBot {
         let (_dummy_tx, dummy_rx) = tokio::sync::mpsc::channel::<PythPriceUpdate>(1);
         let mut pyth_price_feed = self.pyth_price_feed.unwrap_or(dummy_rx);
 
+        // Swift retry mechanism
+        const MAX_SWIFT_RECONNECT_RETRIES: u32 = 10;
+        let mut retries = 0u32;
         loop {
             tokio::select! {
                 biased;
                 swift_order = swift_order_stream.next() => {
                     match swift_order {
                         Some(signed_order) => {
+                            // reset
+                            retries = 0;
+
                             // try swift fill against resting liquidity
                             let mut order_params = signed_order.order_params();
                             log::info!(target: TARGET, "new swift order. uuid={}, market={}", signed_order.order_uuid_str(), order_params.market_index);
@@ -262,8 +268,26 @@ impl FillerBot {
                             }
                         }
                         None => {
-                            log::error!(target: TARGET, "swift order stream finished");
-                            break;
+                            retries += 1;
+                            if retries <= MAX_SWIFT_RECONNECT_RETRIES {
+                                    let backoff = 2u64.pow(retries).min(30);
+                                    log::warn!(target: "swift", "feed disconnected, retry {retries}/{MAX_SWIFT_RECONNECT_RETRIES} in {backoff}s");
+                                    tokio::time::sleep(Duration::from_secs(backoff)).await;
+
+                                    match drift
+                                        .subscribe_swift_orders(&market_ids, Some(true), None, None)
+                                        .await
+                                    {
+                                        Ok(stream) => swift_order_stream = stream,
+                                        Err(e) => {
+                                            log::error!(target: "swift", "resubscribe failed: {e:?}");
+                                            continue;
+                                        }
+                                    }
+                                } else {
+                                    log::error!(target: TARGET, "swift order stream finished after {MAX_SWIFT_RECONNECT_RETRIES} retries");
+                                    break;
+                                }
                         }
                     }
                 }

--- a/src/filler.rs
+++ b/src/filler.rs
@@ -1022,7 +1022,7 @@ pub struct TxWorker {
     metrics: Arc<Metrics>,
     dry_run: bool,
     txs_in_flight: Option<Arc<DashMap<Pubkey, HashSet<Signature>>>>,
-    tx_sig_to_collateral: Option<Arc<DashMap<Signature, u128>>>,
+    tx_sig_to_collateral: Option<Arc<DashMap<Signature, (u128, u64)>>>,
     free_collateral_per_subaccount: Option<Arc<DashMap<Pubkey, u128>>>,
 }
 
@@ -1032,7 +1032,7 @@ impl TxWorker {
         metrics: Arc<Metrics>,
         dry_run: bool,
         txs_in_flight: Option<Arc<DashMap<Pubkey, HashSet<Signature>>>>,
-        tx_sig_to_collateral: Option<Arc<DashMap<Signature, u128>>>,
+        tx_sig_to_collateral: Option<Arc<DashMap<Signature, (u128, u64)>>>,
         free_collateral_per_subaccount: Option<Arc<DashMap<Pubkey, u128>>>,
     ) -> Self {
         Self {
@@ -1301,6 +1301,21 @@ impl TxWorker {
                                     }
                                     _ => {}
                                 }
+
+                                if let (Some(tx_sig_map), Some(txs_map), Some(free_map)) =
+                                    (&tx_sig_to_collateral, &txs_in_flight, &free_collateral)
+                                {
+                                    if let Some((_sig, (collateral, _ts))) = tx_sig_map.remove(&signature) {
+                                        for mut entry in txs_map.iter_mut() {
+                                            if entry.value_mut().remove(&signature) {
+                                                if let Some(mut free) = free_map.get_mut(entry.key()) {
+                                                    *free = free.saturating_add(collateral);
+                                                }
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     } else {
@@ -1317,21 +1332,6 @@ impl TxWorker {
                         .tx_failed
                         .with_label_values(&[intent_label, "confirmation_failed"])
                         .inc();
-                }
-            }
-
-            if let (Some(tx_sig_map), Some(txs_map), Some(free_map)) =
-                (&tx_sig_to_collateral, &txs_in_flight, &free_collateral)
-            {
-                if let Some((_, collateral)) = tx_sig_map.remove(&signature) {
-                    for mut entry in txs_map.iter_mut() {
-                        if entry.value_mut().remove(&signature) {
-                            if let Some(mut free) = free_map.get_mut(entry.key()) {
-                                *free = free.saturating_add(collateral);
-                            }
-                            break;
-                        }
-                    }
                 }
             }
         });

--- a/src/http.rs
+++ b/src/http.rs
@@ -25,6 +25,27 @@ pub enum MarginStatus {
     Safe,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserMarginStatus {
+    pub cross: MarginStatus,
+    /// Only contains isolated positions that are high risk or liquidatable
+    pub isolated: Vec<(u16, MarginStatus)>, // (market_index, status)
+}
+
+impl UserMarginStatus {
+    pub fn is_liquidatable(&self) -> bool {
+        self.cross == MarginStatus::Liquidatable
+            || self
+                .isolated
+                .iter()
+                .any(|(_, s)| *s == MarginStatus::Liquidatable)
+    }
+
+    pub fn is_at_risk(&self) -> bool {
+        self.cross != MarginStatus::Safe || !self.isolated.is_empty()
+    }
+}
+
 /// Market type for positions and oracles
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -602,7 +602,7 @@ impl LiquidatorBot {
                     Err(TryRecvError::Empty) => break 'pyth,
                 }
             }
-
+            events_rx.recv_many(&mut event_buffer, 64).await;
             for event in event_buffer.drain(..) {
                 match event {
                     GrpcEvent::UserUpdate {

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -525,6 +525,8 @@ impl LiquidatorBot {
             Arc::clone(&priority_fee_subscriber),
         );
 
+        log::info!(target: TARGET, "spawned liquidation worker");
+
         LiquidatorBot {
             drift,
             dlob_notifier,
@@ -558,6 +560,9 @@ impl LiquidatorBot {
         // initialize local User storage
         let mut exclude_count = 0;
         let mut initial_high_risk_count = 0;
+
+        log::info!(target: TARGET, "starting user account initialization");
+
         drift
             .backend()
             .account_map()
@@ -599,8 +604,8 @@ impl LiquidatorBot {
                 }
             });
 
-        log::debug!(target: TARGET, "filtered #{exclude_count} accounts with dust collateral");
-        log::debug!(target: TARGET, "identified #{initial_high_risk_count} high-risk accounts for monitoring");
+        log::info!(target: TARGET, "filtered #{exclude_count} accounts with dust collateral");
+        log::info!(target: TARGET, "identified #{initial_high_risk_count} high-risk accounts for monitoring");
 
         // main loop
         let mut event_buffer = Vec::<GrpcEvent>::with_capacity(64);

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -1880,27 +1880,34 @@ impl LiquidateWithMatchStrategy {
             return;
         };
 
-        // Check if we have enough collateral
+        // Check available collateral
         let collateral_map = collateral_info_per_subaccount.read().unwrap();
         let Some(collateral_info) = collateral_map.get(&keeper_subaccount) else {
             log::warn!(target: TARGET, "no collateral info for keeper subaccount");
             return;
         };
 
-        if collateral_info.free < collateral_required as i128 {
-            log::info!(
-                target: TARGET,
-                "insufficient collateral: need {}, have {}",
-                collateral_required,
-                collateral_info.free
-            );
-            return;
-        }
+        // Calculate amount to be liquidated (full or partial)
+        let base_asset_amount_to_be_liquidated =
+            if collateral_info.free >= collateral_required as i128 {
+                pos.base_asset_amount.unsigned_abs()
+            } else {
+                // Scale down to 90% of available collateral
+                let scale_factor = (collateral_info.free as f64 / collateral_required as f64) * 0.9;
+                (pos.base_asset_amount.unsigned_abs() as f64 * scale_factor) as u64
+            };
 
         metrics
             .liquidation_attempts
             .with_label_values(&["perp"])
             .inc();
+
+        let oracle_price = market_state
+            .get_perp_oracle_price(pos.market_index)
+            .map(|x| x.price)
+            .unwrap_or(0) as u64;
+
+        let pyth_update = pyth_price_update.filter(|update| update.price != oracle_price);
 
         let Some(makers) = Self::find_top_makers(
             drift,
@@ -1909,6 +1916,18 @@ impl LiquidateWithMatchStrategy {
             pos.market_index,
             pos.base_asset_amount,
         ) else {
+            try_liquidate_with_collateral(
+                &drift,
+                pos.market_index,
+                keeper_subaccount,
+                liquidatee,
+                base_asset_amount_to_be_liquidated,
+                tx_sender,
+                priority_fee,
+                cu_limit,
+                slot,
+                pyth_update,
+            );
             return;
         };
 
@@ -1937,19 +1956,6 @@ impl LiquidateWithMatchStrategy {
             slot,
             pyth_update,
         );
-
-        // try_liquidate_with_collateral(
-        //     &drift,
-        //     pos.market_index,
-        //     keeper_subaccount,
-        //     liquidatee,
-        //     pos.base_asset_amount.unsigned_abs(),
-        //     tx_sender,
-        //     priority_fee,
-        //     cu_limit,
-        //     slot,
-        //     pyth_update,
-        // );
     }
 
     /// Attempt spot liquidation with Jupiter swap

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -653,7 +653,10 @@ impl LiquidatorBot {
                         log::error!(target: TARGET, "pyth price feed disconnected");
                         return;
                     }
-                    Err(TryRecvError::Empty) => break 'pyth,
+                    Err(TryRecvError::Empty) => {
+                        log::info!(target: TARGET, "pyth empty");
+                        break 'pyth;
+                    }
                 }
             }
 

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -1656,24 +1656,25 @@ fn try_liquidate_perp_pnl_for_deposit(
         tx_builder = tx_builder.post_pyth_lazer_oracle_update(&[update.feed_id], &update.message);
     }
 
-    // tx_builder = tx_builder.liquidate_perp_pnl_for_deposit(
-    //     liability.market_index,
-    //     asset.market_index,
-    //     &liquidatee_account,
-    // );
+    tx_builder = tx_builder.liquidate_perp_pnl_for_deposit(
+        &liquidatee_account,
+        asset.market_index,
+        liability.market_index,
+        base_asset_amount,
+    );
 
-    // let tx = tx_builder.build();
+    let tx = tx_builder.build();
 
-    // tx_sender.send_tx(
-    //     tx,
-    //     TxIntent::LiquidatePerpPnlForDeposit {
-    //         perp_market_index: liability.market_index,
-    //         spot_market_index: asset.market_index,
-    //         liquidatee,
-    //         slot,
-    //     },
-    //     cu_limit as u64,
-    // );
+    tx_sender.send_tx(
+        tx,
+        TxIntent::LiquidatePerpPnlForDeposit {
+            perp_market_index: liability.market_index,
+            spot_market_index: asset.market_index,
+            liquidatee,
+            slot,
+        },
+        cu_limit as u64,
+    );
 }
 
 fn spawn_liquidation_worker(

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -25,7 +25,7 @@ use drift_rs::{
     math::{
         constants::{
             BASE_PRECISION, BASE_PRECISION_U64, MARGIN_PRECISION_U128, PRICE_PRECISION,
-            QUOTE_PRECISION, SPOT_WEIGHT_PRECISION_U128,
+            QUOTE_PRECISION, QUOTE_PRECISION_U64, SPOT_WEIGHT_PRECISION_U128,
         },
         liquidation::{calculate_collateral, CollateralInfo},
         tiers::perp_tier_is_as_safe_as,
@@ -611,6 +611,7 @@ impl LiquidatorBot {
 
         let tx_sig_to_collateral_clone = Arc::clone(&tx_sig_to_collateral);
         let txs_in_flight_clone = Arc::clone(&txs_in_flight);
+        let free_collateral_per_subaccount_clone = Arc::clone(&free_collateral_per_subaccount);
 
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(30));
@@ -619,6 +620,7 @@ impl LiquidatorBot {
                 clean_stale_in_flight_txs(
                     Arc::clone(&tx_sig_to_collateral_clone),
                     Arc::clone(&txs_in_flight_clone),
+                    Arc::clone(&free_collateral_per_subaccount_clone),
                 );
             }
         });
@@ -1261,19 +1263,33 @@ impl LiquidatorBot {
 fn clean_stale_in_flight_txs(
     tx_sig_to_collateral: Arc<DashMap<Signature, (u128, u64)>>,
     txs_in_flight: Arc<DashMap<Pubkey, HashSet<Signature>>>,
+    free_collateral_per_subaccount: Arc<DashMap<Pubkey, u128>>,
 ) {
     let now = current_time_millis();
     let timeout_ms = 60_000;
 
-    tx_sig_to_collateral.retain(|sig, (_, ts)| {
-        let is_stale = now.saturating_sub(*ts) > timeout_ms;
-        if is_stale {
-            for mut entry in txs_in_flight.iter_mut() {
-                entry.value_mut().remove(sig);
+    let stale: Vec<(Signature, u128)> = tx_sig_to_collateral
+        .iter()
+        .filter_map(|entry| {
+            if now.saturating_sub(entry.value().1) > timeout_ms {
+                Some((*entry.key(), entry.value().0))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    for (sig, collateral) in stale {
+        tx_sig_to_collateral.remove(&sig);
+        for mut entry in txs_in_flight.iter_mut() {
+            if entry.value_mut().remove(&sig) {
+                if let Some(mut free) = free_collateral_per_subaccount.get_mut(entry.key()) {
+                    *free = free.saturating_add(collateral);
+                }
+                break;
             }
         }
-        !is_stale
-    });
+    }
 }
 
 async fn derisk_subaccount(
@@ -1711,7 +1727,7 @@ impl PrimaryLiquidationStrategy {
         collateral_required: u128,
         has_makers: bool,
     ) -> LiquidationType {
-        const POSITION_AMOUNT_THRESHOLD: u64 = 5_000 * BASE_PRECISION_U64;
+        const POSITION_AMOUNT_THRESHOLD: u64 = 5_000 * QUOTE_PRECISION_U64;
 
         let is_small_position = quote_asset_amount <= POSITION_AMOUNT_THRESHOLD;
         let can_afford_takeover = collateral_available >= collateral_required;

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -18,8 +18,11 @@ use tokio::sync::mpsc::error::TryRecvError;
 
 use drift_rs::{
     dlob::{DLOBNotifier, DLOB},
-    ffi::{calculate_claimable_pnl, OraclePriceData, SimplifiedMarginCalculation},
-    grpc::{grpc_subscriber::AccountFilter, TransactionUpdate},
+    ffi::{OraclePriceData, SimplifiedMarginCalculation},
+    grpc::{
+        grpc_subscriber::{AccountFilter, GrpcConnectionOpts},
+        TransactionUpdate,
+    },
     jupiter::SwapMode,
     market_state::MarketStateData,
     math::{
@@ -312,18 +315,23 @@ fn check_margin_status(margin_info: &SimplifiedMarginCalculation) -> UserMarginS
 
     // Check isolated positions
     for calc in &margin_info.isolated_margin_calculations {
-        if !calc.is_empty() {
-            let buffered_iso_margin_req =
-                (calc.margin_requirement as f64 * LIQUIDATION_BUFFER) as i128;
-            if calc.total_collateral < buffered_iso_margin_req {
-                isolated.push((calc.market_index, MarginStatus::Liquidatable));
-            } else {
-                let free_margin = calc.total_collateral - calc.margin_requirement as i128;
-                if calc.margin_requirement > 0 && free_margin > 0 {
-                    let free_margin_ratio = free_margin as f64 / calc.margin_requirement as f64;
-                    if free_margin_ratio < HIGH_RISK_FREE_MARGIN_RATIO {
-                        isolated.push((calc.market_index, MarginStatus::HighRisk));
-                    }
+        if calc.is_empty() {
+            continue;
+        }
+
+        if calc.total_collateral <= 0 {
+            continue;
+        }
+
+        let buffered_iso_margin_req = (calc.margin_requirement as f64 * LIQUIDATION_BUFFER) as i128;
+        if calc.total_collateral < buffered_iso_margin_req {
+            isolated.push((calc.market_index, MarginStatus::Liquidatable));
+        } else {
+            let free_margin = calc.total_collateral - calc.margin_requirement as i128;
+            if calc.margin_requirement > 0 && free_margin > 0 {
+                let free_margin_ratio = free_margin as f64 / calc.margin_requirement as f64;
+                if free_margin_ratio < HIGH_RISK_FREE_MARGIN_RATIO {
+                    isolated.push((calc.market_index, MarginStatus::HighRisk));
                 }
             }
         }
@@ -893,6 +901,7 @@ impl LiquidatorBot {
                         market,
                         slot,
                     } => {
+                        log::debug!(target: TARGET, "oracle update received: market={:?}, slot={}", market, slot);
                         if slot >= current_slot {
                             if market.is_perp() {
                                 if oracle_price_data.price > 0 {
@@ -1479,6 +1488,8 @@ async fn setup_grpc(
             .or_insert(vec![(*market, *source)]);
     }
 
+    log::info!(target: TARGET, "oracle map has {} oracles", oracle_to_market.len());
+
     let _res = drift
         .grpc_subscribe(
             std::env::var("GRPC_ENDPOINT")
@@ -1486,6 +1497,7 @@ async fn setup_grpc(
                 .into(),
             std::env::var("GRPC_X_TOKEN").expect("GRPC_X_TOKEN set"),
             GrpcSubscribeOpts::default()
+                .connection_opts(GrpcConnectionOpts::default().enable_compression())
                 .commitment(solana_sdk::commitment_config::CommitmentLevel::Processed)
                 .transaction_include_accounts(vec![drift.wallet().default_sub_account()])
                 .on_transaction(on_transaction_update_fn(transaction_tx.clone()))

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -40,7 +40,9 @@ use drift_rs::{
     DriftClient, GrpcSubscribeOpts, MarketState, Pubkey, TransactionBuilder, Wallet,
 };
 use drift_rs::{jupiter::JupiterSwapApi, titan::TitanSwapApi};
-use solana_sdk::{account::Account, clock::Slot, compute_budget::ComputeBudgetInstruction};
+use solana_sdk::{
+    account::Account, clock::Slot, compute_budget::ComputeBudgetInstruction, signature::Signature,
+};
 
 use crate::{
     filler::{TxSender, TxWorker},
@@ -360,7 +362,6 @@ pub trait LiquidationStrategy {
         cu_limit: u32,
         slot: u64,
         pyth_price_update: Option<PythPriceUpdate>,
-        collateral_info_per_subaccount: Arc<DashMap<Pubkey, CollateralInfo>>,
         status: UserMarginStatus,
     ) -> futures_util::future::BoxFuture<'a, ()>;
 }
@@ -406,8 +407,13 @@ pub struct LiquidatorBot {
     pyth_price_feed: Option<tokio::sync::mpsc::Receiver<PythPriceUpdate>>,
     /// Dashboard state for HTTP API
     dashboard_state: DashboardStateRef,
+    subaccount_pubkeys: Vec<Pubkey>,
     /// Track collateral info per subaccount
     collateral_info_per_subaccount: Arc<DashMap<Pubkey, CollateralInfo>>,
+    /// In flight txs tracking
+    txs_in_flight: Arc<DashMap<Pubkey, HashSet<Signature>>>,
+    tx_sig_to_collateral: Arc<DashMap<Signature, u128>>,
+    free_collateral_per_subaccount: Arc<DashMap<Pubkey, u128>>,
 }
 
 impl LiquidatorBot {
@@ -418,9 +424,6 @@ impl LiquidatorBot {
         dashboard_state: DashboardStateRef,
     ) -> Self {
         let dlob: &'static DLOB = Box::leak(Box::new(DLOB::default()));
-        let tx_worker = TxWorker::new(drift.clone(), Arc::clone(&metrics), config.dry);
-        let rt = tokio::runtime::Handle::current();
-        let tx_sender = tx_worker.run(rt);
 
         let mut perp_market_ids = match config.use_markets() {
             UseMarkets::All => drift.get_all_perp_market_ids(),
@@ -471,6 +474,42 @@ impl LiquidatorBot {
         log::info!(target: TARGET, "liquidator 🫠 bot started: authority={:?}, subaccount={:?}", drift.wallet.authority(), subaccounts);
 
         drift.subscribe_blockhashes().await.expect("subscribed");
+
+        let subaccount_pubkeys: Vec<Pubkey> = config
+            .get_subaccounts()
+            .iter()
+            .map(|id| drift.wallet.sub_account(*id))
+            .collect();
+
+        let collateral_info_per_subaccount =
+            Arc::new(get_collateral_info_per_subaccount(&drift, &subaccount_pubkeys).await);
+
+        // In flight txs tracking to prevent over committing
+        let (txs_in_flight, free_collateral_per_subaccount) = {
+            let txs = DashMap::new();
+            let free = DashMap::new();
+            for &subaccount in &subaccount_pubkeys {
+                txs.insert(subaccount, HashSet::new());
+                if let Some(info) = collateral_info_per_subaccount.get(&subaccount) {
+                    free.insert(subaccount, info.free.max(0) as u128);
+                }
+            }
+            (Arc::new(txs), Arc::new(free))
+        };
+
+        let tx_sig_to_collateral = Arc::new(DashMap::new());
+
+        let tx_worker = TxWorker::new(
+            drift.clone(),
+            Arc::clone(&metrics),
+            config.dry,
+            Some(Arc::clone(&txs_in_flight)),
+            Some(Arc::clone(&tx_sig_to_collateral)),
+            Some(Arc::clone(&free_collateral_per_subaccount)),
+        );
+        let rt = tokio::runtime::Handle::current();
+        let tx_sender = tx_worker.run(rt);
+
         let dlob_notifier = dlob.spawn_notifier();
         let events_rx = setup_grpc(
             drift.clone(),
@@ -496,6 +535,7 @@ impl LiquidatorBot {
                 market_state.set_perp_oracle_price(market.market_index, oracle.data);
             }
         }
+
         for market in drift.program_data().spot_market_configs() {
             market_state.set_spot_market(*market);
             if let Some(oracle) = drift
@@ -524,9 +564,6 @@ impl LiquidatorBot {
 
         log::info!(target: TARGET, "subscribed pyth price feeds");
 
-        let collateral_info_per_subaccount =
-            Arc::new(get_collateral_info_per_subaccount(&drift, &config.get_subaccounts()).await);
-
         let cu_limit = std::env::var("FILL_CU_LIMIT")
             .ok()
             .and_then(|s| s.parse::<u32>().ok())
@@ -550,11 +587,13 @@ impl LiquidatorBot {
                 subaccounts: subaccounts.clone(),
                 metrics: Arc::clone(&metrics),
                 use_spot_liquidation: config.use_spot_liquidation,
+                txs_in_flight: Arc::clone(&txs_in_flight),
+                tx_sig_to_collateral: Arc::clone(&tx_sig_to_collateral),
+                free_collateral_per_subaccount: Arc::clone(&free_collateral_per_subaccount),
             }),
             liq_rx,
             cu_limit,
             Arc::clone(&priority_fee_subscriber),
-            Arc::clone(&collateral_info_per_subaccount),
         );
 
         log::info!(target: TARGET, "spawned liquidation worker");
@@ -578,7 +617,11 @@ impl LiquidatorBot {
             liq_tx,
             pyth_price_feed: Some(pyth_price_feed),
             dashboard_state,
+            subaccount_pubkeys,
             collateral_info_per_subaccount,
+            txs_in_flight,
+            tx_sig_to_collateral,
+            free_collateral_per_subaccount,
         }
     }
 
@@ -721,14 +764,31 @@ impl LiquidatorBot {
                     } => {
                         // Update collaterals
                         let new_collateral =
-                            get_collateral_info_per_subaccount(&drift, &config.get_subaccounts())
+                            get_collateral_info_per_subaccount(&drift, &self.subaccount_pubkeys)
                                 .await;
 
                         self.collateral_info_per_subaccount.clear();
 
-                        for (subaccount, collateral_info) in new_collateral {
+                        for (subaccount_pubkey, collateral_info) in new_collateral {
                             self.collateral_info_per_subaccount
-                                .insert(subaccount, collateral_info);
+                                .insert(subaccount_pubkey, collateral_info);
+                        }
+
+                        // Update free collateral accounting for in flight txs
+                        for entry in self.collateral_info_per_subaccount.iter() {
+                            let subaccount_pubkey = entry.key();
+                            let collateral_info = entry.value();
+                            let mut free = collateral_info.free;
+
+                            if let Some(in_flight) = self.txs_in_flight.get(subaccount_pubkey) {
+                                for sig in in_flight.value().iter() {
+                                    if let Some(reserved) = self.tx_sig_to_collateral.get(sig) {
+                                        free = free.saturating_sub(*reserved.value() as i128);
+                                    }
+                                }
+                            }
+                            self.free_collateral_per_subaccount
+                                .insert(*subaccount_pubkey, free.max(0) as u128);
                         }
 
                         let old_user = users.get(&pubkey).map(|m| &m.user);
@@ -1181,7 +1241,7 @@ impl LiquidatorBot {
     }
 }
 
-fn derisk_subaccount(
+async fn derisk_subaccount(
     drift: &DriftClient,
     tx_sender: &TxSender,
     subaccount: Pubkey,
@@ -1224,25 +1284,29 @@ fn derisk_subaccount(
                 ..Default::default()
             }]);
 
-            tx_sender.send_tx(
-                tx_builder.build(),
-                TxIntent::Derisk {
-                    market_index: position.market_index,
-                    subaccount,
-                },
-                cu_limit as u64,
-            );
+            tx_sender
+                .send_tx(
+                    tx_builder.build(),
+                    TxIntent::Derisk {
+                        market_index: position.market_index,
+                        subaccount,
+                    },
+                    cu_limit as u64,
+                )
+                .await;
         } else {
             tx_builder = tx_builder.settle_pnl(position.market_index, None, None);
 
-            tx_sender.send_tx(
-                tx_builder.build(),
-                TxIntent::SettlePnl {
-                    market_index: position.market_index,
-                    subaccount,
-                },
-                cu_limit as u64,
-            );
+            tx_sender
+                .send_tx(
+                    tx_builder.build(),
+                    TxIntent::SettlePnl {
+                        market_index: position.market_index,
+                        subaccount,
+                    },
+                    cu_limit as u64,
+                )
+                .await;
         }
     }
 
@@ -1262,7 +1326,7 @@ fn spawn_derisk_loop(
             interval.tick().await;
             let priority_fee = priority_fee_subscriber.priority_fee_nth(0.6);
             for subaccount in &subaccounts {
-                derisk_subaccount(&drift, &tx_sender, *subaccount, priority_fee, cu_limit);
+                derisk_subaccount(&drift, &tx_sender, *subaccount, priority_fee, cu_limit).await;
             }
         }
     });
@@ -1270,11 +1334,10 @@ fn spawn_derisk_loop(
 
 async fn get_collateral_info_per_subaccount(
     drift: &DriftClient,
-    subaccounts: &[u16],
+    subaccounts: &[Pubkey],
 ) -> DashMap<Pubkey, CollateralInfo> {
     let collateral_info_per_subaccount = DashMap::<Pubkey, CollateralInfo>::new();
-    for subaccount in subaccounts {
-        let subaccount_pubkey = Wallet::derive_user_account(&drift.wallet.authority(), *subaccount);
+    for &subaccount_pubkey in subaccounts {
         match drift.get_user_account(&subaccount_pubkey).await {
             Ok(user_account) => {
                 match calculate_collateral(
@@ -1287,7 +1350,7 @@ async fn get_collateral_info_per_subaccount(
                         log::info!(
                             target: TARGET,
                             "Subaccount {}: free_collateral = {}, total_collateral = {}",
-                            subaccount,
+                            subaccount_pubkey,
                             collateral_info.free,
                             collateral_info.total
                         );
@@ -1296,7 +1359,7 @@ async fn get_collateral_info_per_subaccount(
                         log::warn!(
                             target: TARGET,
                             "Failed to calculate collateral for subaccount {}: {:?}",
-                            subaccount,
+                            subaccount_pubkey,
                             e
                         );
                     }
@@ -1306,7 +1369,7 @@ async fn get_collateral_info_per_subaccount(
                 log::warn!(
                     target: TARGET,
                     "Failed to load subaccount {}: {:?}",
-                    subaccount,
+                    subaccount_pubkey,
                     e
                 );
             }
@@ -1469,268 +1532,6 @@ async fn setup_grpc(
     rx
 }
 
-/// Try to fill liquidation with order match
-fn try_liquidate_with_match(
-    drift: &DriftClient,
-    market_index: u16,
-    subaccount: Pubkey,
-    liquidatee_subaccount: Pubkey,
-    top_makers: &[User],
-    tx_sender: TxSender,
-    priority_fee: u64,
-    cu_limit: u32,
-    slot: u64,
-    pyth_price_update: Option<PythPriceUpdate>,
-) {
-    if top_makers.is_empty() {
-        log::debug!(target: TARGET, "skip empty maker cross. market={market_index} user={liquidatee_subaccount}");
-        return;
-    }
-
-    let keeper_account_data = drift.try_get_account::<User>(&subaccount);
-    if keeper_account_data.is_err() {
-        log::debug!(target: TARGET, "keeper acc lookup failed={subaccount:?}");
-        return;
-    }
-    let liquidatee_subaccount_data = drift.try_get_account::<User>(&liquidatee_subaccount);
-    if liquidatee_subaccount_data.is_err() {
-        log::debug!(target: TARGET, "liquidatee acc lookup failed={liquidatee_subaccount:?}");
-        return;
-    }
-
-    let mut tx_builder = TransactionBuilder::new(
-        drift.program_data(),
-        subaccount,
-        std::borrow::Cow::Owned(keeper_account_data.unwrap()),
-        false,
-    )
-    .with_priority_fee(priority_fee, Some(cu_limit));
-
-    if let Some(ref update) = pyth_price_update {
-        tx_builder = tx_builder.post_pyth_lazer_oracle_update(&[update.feed_id], &update.message);
-    }
-
-    tx_builder = tx_builder.liquidate_perp_with_fill(
-        market_index,
-        &liquidatee_subaccount_data.unwrap(),
-        top_makers,
-    );
-
-    // large accounts list, bump CU limit to compensate
-    if let Some(ix) = tx_builder.ixs().last() {
-        if ix.accounts.len() >= 20 {
-            tx_builder = tx_builder.set_ix(
-                1,
-                ComputeBudgetInstruction::set_compute_unit_limit(cu_limit * 2),
-            );
-        }
-    }
-
-    let tx = tx_builder.build();
-
-    tx_sender.send_tx(
-        tx,
-        TxIntent::LiquidateWithFill {
-            market_index,
-            liquidatee: liquidatee_subaccount,
-            slot,
-        },
-        cu_limit as u64,
-    );
-}
-
-/// Try to liquidate by taking over position
-fn try_liquidate_with_collateral(
-    drift: &DriftClient,
-    market_index: u16,
-    subaccount: Pubkey,
-    liquidatee_subaccount: Pubkey,
-    base_asset_amount: u64,
-    tx_sender: TxSender,
-    priority_fee: u64,
-    cu_limit: u32,
-    slot: u64,
-    pyth_price_update: Option<PythPriceUpdate>,
-) {
-    let keeper_account_data = drift.try_get_account::<User>(&subaccount);
-    if keeper_account_data.is_err() {
-        log::debug!(target: TARGET, "keeper acc lookup failed={subaccount:?}");
-        return;
-    }
-    let liquidatee_subaccount_data = drift.try_get_account::<User>(&liquidatee_subaccount);
-    if liquidatee_subaccount_data.is_err() {
-        log::debug!(target: TARGET, "liquidatee acc lookup failed={liquidatee_subaccount:?}");
-        return;
-    }
-
-    let mut tx_builder = TransactionBuilder::new(
-        drift.program_data(),
-        subaccount,
-        std::borrow::Cow::Owned(keeper_account_data.unwrap()),
-        false,
-    )
-    .with_priority_fee(priority_fee, Some(cu_limit));
-
-    if let Some(ref update) = pyth_price_update {
-        tx_builder = tx_builder.post_pyth_lazer_oracle_update(&[update.feed_id], &update.message);
-    }
-
-    tx_builder = tx_builder.liquidate_perp(
-        market_index,
-        &liquidatee_subaccount_data.unwrap(),
-        base_asset_amount,
-        None,
-    );
-
-    // large accounts list, bump CU limit to compensate
-    if let Some(ix) = tx_builder.ixs().last() {
-        if ix.accounts.len() >= 20 {
-            tx_builder = tx_builder.set_ix(
-                1,
-                ComputeBudgetInstruction::set_compute_unit_limit(cu_limit * 2),
-            );
-        }
-    }
-
-    let tx = tx_builder.build();
-
-    tx_sender.send_tx(
-        tx,
-        TxIntent::LiquidatePerp {
-            market_index,
-            liquidatee: liquidatee_subaccount,
-            slot,
-        },
-        cu_limit as u64,
-    );
-}
-
-fn try_liquidate_perp_pnl_for_deposit(
-    drift: &DriftClient,
-    subaccount: Pubkey,
-    liquidatee: Pubkey,
-    liability: &PositionInfo,
-    asset: &PositionInfo,
-    liq_amount: u128,
-    tx_sender: TxSender,
-    priority_fee: u64,
-    cu_limit: u32,
-    slot: u64,
-    pyth_price_update: Option<PythPriceUpdate>,
-) {
-    let keeper_account = match drift.try_get_account::<User>(&subaccount) {
-        Ok(data) => data,
-        Err(_) => {
-            log::warn!(target: TARGET, "keeper account not found");
-            return;
-        }
-    };
-
-    let liquidatee_account = match drift.try_get_account::<User>(&liquidatee) {
-        Ok(data) => data,
-        Err(_) => {
-            log::warn!(target: TARGET, "liquidatee account not found");
-            return;
-        }
-    };
-
-    let mut tx_builder = TransactionBuilder::new(
-        drift.program_data(),
-        subaccount,
-        std::borrow::Cow::Owned(keeper_account),
-        false,
-    )
-    .with_priority_fee(priority_fee, Some(cu_limit));
-
-    if let Some(ref update) = pyth_price_update {
-        tx_builder = tx_builder.post_pyth_lazer_oracle_update(&[update.feed_id], &update.message);
-    }
-
-    tx_builder = tx_builder.liquidate_perp_pnl_for_deposit(
-        &liquidatee_account,
-        liability.market_index,
-        asset.market_index,
-        drift_rs::types::u128::from(liq_amount),
-        None,
-    );
-
-    let tx = tx_builder.build();
-
-    tx_sender.send_tx(
-        tx,
-        TxIntent::LiquidatePerpPnlForDeposit {
-            perp_market_index: liability.market_index,
-            spot_market_index: asset.market_index,
-            liquidatee,
-            slot,
-        },
-        cu_limit as u64,
-    );
-}
-
-fn try_liquidate_borrow_for_perp_pnl(
-    drift: &DriftClient,
-    subaccount: Pubkey,
-    liquidatee: Pubkey,
-    liability: &PositionInfo,
-    asset: &PositionInfo,
-    liq_amount: u128,
-    tx_sender: TxSender,
-    priority_fee: u64,
-    cu_limit: u32,
-    slot: u64,
-    pyth_price_update: Option<PythPriceUpdate>,
-) {
-    let keeper_account = match drift.try_get_account::<User>(&subaccount) {
-        Ok(data) => data,
-        Err(_) => {
-            log::warn!(target: TARGET, "keeper account not found");
-            return;
-        }
-    };
-
-    let liquidatee_account = match drift.try_get_account::<User>(&liquidatee) {
-        Ok(data) => data,
-        Err(_) => {
-            log::warn!(target: TARGET, "liquidatee account not found");
-            return;
-        }
-    };
-
-    let mut tx_builder = TransactionBuilder::new(
-        drift.program_data(),
-        subaccount,
-        std::borrow::Cow::Owned(keeper_account),
-        false,
-    )
-    .with_priority_fee(priority_fee, Some(cu_limit));
-
-    if let Some(ref update) = pyth_price_update {
-        tx_builder = tx_builder.post_pyth_lazer_oracle_update(&[update.feed_id], &update.message);
-    }
-
-    tx_builder = tx_builder.liquidate_borrow_for_perp_pnl(
-        &liquidatee_account,
-        asset.market_index,
-        liability.market_index,
-        drift_rs::types::u128::from(liq_amount),
-        None,
-    );
-
-    let tx = tx_builder.build();
-
-    tx_sender.send_tx(
-        tx,
-        TxIntent::LiquidateBorrowForPerpPnl {
-            perp_market_index: asset.market_index,
-            spot_market_index: liability.market_index,
-            liquidatee,
-            slot,
-        },
-        cu_limit as u64,
-    );
-}
-
 fn spawn_liquidation_worker(
     tx_sender: TxSender,
     strategy: Arc<dyn LiquidationStrategy + Send + Sync>,
@@ -1744,7 +1545,6 @@ fn spawn_liquidation_worker(
     )>,
     cu_limit: u32,
     priority_fee_subscriber: Arc<PriorityFeeSubscriber>,
-    collateral_info_per_subaccount: Arc<DashMap<Pubkey, CollateralInfo>>,
 ) {
     let mut rate_limit = HashMap::<Pubkey, u64>::new();
 
@@ -1779,7 +1579,6 @@ fn spawn_liquidation_worker(
             let liquidatee_clone = liquidatee;
             let user_account_clone = Arc::new(user_account);
             let tx_sender_clone = tx_sender.clone();
-            let collateral_info_clone = Arc::clone(&collateral_info_per_subaccount);
 
             tokio::spawn(async move {
                 let deadline = std::time::Duration::from_millis(LIQUIDATION_DEADLINE_MS);
@@ -1794,7 +1593,6 @@ fn spawn_liquidation_worker(
                         cu_limit,
                         slot,
                         pyth_price_update,
-                        collateral_info_clone,
                         status,
                     ),
                 )
@@ -1836,6 +1634,7 @@ fn spawn_liquidation_worker(
 }
 
 enum LiquidationType {
+    SettlePnl,
     PerpWithFill,
     PerpTakeover,
     PerpPnlForDeposit,
@@ -1854,7 +1653,7 @@ struct PositionInfo {
     quote_amount: i64,
 }
 
-/// Primary liquidation strategy: Prefers takeover for large positions, uses maker matching for rest
+/// Primary liquidation strategy
 pub struct PrimaryLiquidationStrategy {
     pub drift: DriftClient,
     pub dlob: &'static DLOB,
@@ -1862,6 +1661,9 @@ pub struct PrimaryLiquidationStrategy {
     pub subaccounts: Vec<Pubkey>,
     pub metrics: Arc<Metrics>,
     pub use_spot_liquidation: bool,
+    pub txs_in_flight: Arc<DashMap<Pubkey, HashSet<Signature>>>,
+    pub tx_sig_to_collateral: Arc<DashMap<Signature, u128>>,
+    pub free_collateral_per_subaccount: Arc<DashMap<Pubkey, u128>>,
 }
 
 impl PrimaryLiquidationStrategy {
@@ -1869,14 +1671,14 @@ impl PrimaryLiquidationStrategy {
     /// fallback to takeover when no makers available. Skip if no makers and insufficient collateral.
     fn decide_perp_method(
         quote_asset_amount: u64,
-        collateral_available: i128,
+        collateral_available: u128,
         collateral_required: u128,
         has_makers: bool,
     ) -> LiquidationType {
         const POSITION_AMOUNT_THRESHOLD: u64 = 5_000 * BASE_PRECISION_U64;
 
         let is_small_position = quote_asset_amount <= POSITION_AMOUNT_THRESHOLD;
-        let can_afford_takeover = collateral_available >= collateral_required as i128;
+        let can_afford_takeover = collateral_available >= collateral_required;
 
         if is_small_position && can_afford_takeover {
             LiquidationType::PerpTakeover
@@ -1892,7 +1694,11 @@ impl PrimaryLiquidationStrategy {
     fn decide_liquidation_type(
         liability: &PositionInfo,
         asset: Option<&PositionInfo>,
+        has_pnl_only: bool,
     ) -> LiquidationType {
+        if has_pnl_only {
+            return LiquidationType::SettlePnl;
+        }
         match (liability.market_type, asset.map(|a| a.market_type)) {
             (MarketType::Perp, None) => LiquidationType::PerpTakeover,
             (MarketType::Perp, Some(MarketType::Spot)) => LiquidationType::PerpPnlForDeposit,
@@ -2307,15 +2113,18 @@ impl PrimaryLiquidationStrategy {
         subaccounts: &[Pubkey],
         needs_perp_room: bool,
         needs_spot_room: bool,
-        collateral_info_per_subaccount: &DashMap<Pubkey, CollateralInfo>,
+        free_collateral_per_subaccount: &DashMap<Pubkey, u128>,
         min_collateral_required: u128,
     ) -> Option<Pubkey> {
-        let mut candidates: Vec<(Pubkey, i128)> = subaccounts
+        let mut candidates: Vec<(Pubkey, u128)> = subaccounts
             .iter()
             .filter_map(|&subaccount| {
-                let collateral_info = collateral_info_per_subaccount.get(&subaccount)?;
+                let Some(free_collateral_info) = free_collateral_per_subaccount.get(&subaccount)
+                else {
+                    return None;
+                };
 
-                if collateral_info.free < min_collateral_required as i128 {
+                if *free_collateral_info < min_collateral_required {
                     return None;
                 }
 
@@ -2345,7 +2154,7 @@ impl PrimaryLiquidationStrategy {
                     }
                 }
 
-                Some((subaccount, collateral_info.free))
+                Some((subaccount, *free_collateral_info))
             })
             .collect();
 
@@ -2411,8 +2220,169 @@ impl PrimaryLiquidationStrategy {
         Some(makers)
     }
 
+    /// Try to fill liquidation with order match
+    async fn try_liquidate_with_match(
+        drift: &DriftClient,
+        market_index: u16,
+        subaccount: Pubkey,
+        liquidatee_subaccount: Pubkey,
+        top_makers: &[User],
+        tx_sender: TxSender,
+        priority_fee: u64,
+        cu_limit: u32,
+        slot: u64,
+        pyth_price_update: Option<PythPriceUpdate>,
+    ) {
+        if top_makers.is_empty() {
+            log::debug!(target: TARGET, "skip empty maker cross. market={market_index} user={liquidatee_subaccount}");
+            return;
+        }
+
+        let keeper_account_data = drift.try_get_account::<User>(&subaccount);
+        if keeper_account_data.is_err() {
+            log::debug!(target: TARGET, "keeper acc lookup failed={subaccount:?}");
+            return;
+        }
+        let liquidatee_subaccount_data = drift.try_get_account::<User>(&liquidatee_subaccount);
+        if liquidatee_subaccount_data.is_err() {
+            log::debug!(target: TARGET, "liquidatee acc lookup failed={liquidatee_subaccount:?}");
+            return;
+        }
+
+        let mut tx_builder = TransactionBuilder::new(
+            drift.program_data(),
+            subaccount,
+            std::borrow::Cow::Owned(keeper_account_data.unwrap()),
+            false,
+        )
+        .with_priority_fee(priority_fee, Some(cu_limit));
+
+        if let Some(ref update) = pyth_price_update {
+            tx_builder =
+                tx_builder.post_pyth_lazer_oracle_update(&[update.feed_id], &update.message);
+        }
+
+        tx_builder = tx_builder.liquidate_perp_with_fill(
+            market_index,
+            &liquidatee_subaccount_data.unwrap(),
+            top_makers,
+        );
+
+        // large accounts list, bump CU limit to compensate
+        if let Some(ix) = tx_builder.ixs().last() {
+            if ix.accounts.len() >= 20 {
+                tx_builder = tx_builder.set_ix(
+                    1,
+                    ComputeBudgetInstruction::set_compute_unit_limit(cu_limit * 2),
+                );
+            }
+        }
+
+        let tx = tx_builder.build();
+
+        // Fill doesn't require collateral management
+        tx_sender
+            .send_tx(
+                tx,
+                TxIntent::LiquidateWithFill {
+                    market_index,
+                    liquidatee: liquidatee_subaccount,
+                    slot,
+                },
+                cu_limit as u64,
+            )
+            .await;
+    }
+
+    /// Try to liquidate by taking over position
+    async fn try_liquidate_with_collateral(
+        &self,
+        drift: &DriftClient,
+        market_index: u16,
+        subaccount: Pubkey,
+        liquidatee_subaccount: Pubkey,
+        base_asset_amount: u64,
+        tx_sender: TxSender,
+        priority_fee: u64,
+        cu_limit: u32,
+        slot: u64,
+        pyth_price_update: Option<PythPriceUpdate>,
+    ) {
+        let keeper_account_data = drift.try_get_account::<User>(&subaccount);
+        if keeper_account_data.is_err() {
+            log::debug!(target: TARGET, "keeper acc lookup failed={subaccount:?}");
+            return;
+        }
+        let liquidatee_subaccount_data = drift.try_get_account::<User>(&liquidatee_subaccount);
+        if liquidatee_subaccount_data.is_err() {
+            log::debug!(target: TARGET, "liquidatee acc lookup failed={liquidatee_subaccount:?}");
+            return;
+        }
+
+        let mut tx_builder = TransactionBuilder::new(
+            drift.program_data(),
+            subaccount,
+            std::borrow::Cow::Owned(keeper_account_data.unwrap()),
+            false,
+        )
+        .with_priority_fee(priority_fee, Some(cu_limit));
+
+        if let Some(ref update) = pyth_price_update {
+            tx_builder =
+                tx_builder.post_pyth_lazer_oracle_update(&[update.feed_id], &update.message);
+        }
+
+        tx_builder = tx_builder.liquidate_perp(
+            market_index,
+            &liquidatee_subaccount_data.unwrap(),
+            base_asset_amount,
+            None,
+        );
+
+        // large accounts list, bump CU limit to compensate
+        if let Some(ix) = tx_builder.ixs().last() {
+            if ix.accounts.len() >= 20 {
+                tx_builder = tx_builder.set_ix(
+                    1,
+                    ComputeBudgetInstruction::set_compute_unit_limit(cu_limit * 2),
+                );
+            }
+        }
+
+        let tx = tx_builder.build();
+
+        match tx_sender
+            .send_tx(
+                tx,
+                TxIntent::LiquidatePerp {
+                    market_index,
+                    liquidatee: liquidatee_subaccount,
+                    slot,
+                },
+                cu_limit as u64,
+            )
+            .await
+        {
+            Some(sig) => {
+                self.txs_in_flight
+                    .entry(subaccount)
+                    .or_insert_with(HashSet::new)
+                    .insert(sig);
+
+                self.tx_sig_to_collateral
+                    .insert(sig, base_asset_amount as u128);
+
+                if let Some(mut free) = self.free_collateral_per_subaccount.get_mut(&subaccount) {
+                    *free = free.saturating_sub(base_asset_amount as u128);
+                }
+            }
+            None => return,
+        };
+    }
+
     /// Attempt perp liquidation with order matching or collateral
-    fn liquidate_perp(
+    async fn liquidate_perp(
+        &self,
         drift: &DriftClient,
         dlob: &'static DLOB,
         market_state: Arc<RwLock<MarketState>>,
@@ -2425,7 +2395,6 @@ impl PrimaryLiquidationStrategy {
         cu_limit: u32,
         slot: u64,
         pyth_price_update: Option<PythPriceUpdate>,
-        collateral_info_per_subaccount: Arc<DashMap<Pubkey, CollateralInfo>>,
         status: &UserMarginStatus,
     ) {
         let Some(subaccount) = subaccounts.first() else {
@@ -2474,7 +2443,7 @@ impl PrimaryLiquidationStrategy {
                     let pyth_update =
                         pyth_price_update.filter(|update| update.price != oracle_price);
 
-                    try_liquidate_with_match(
+                    Self::try_liquidate_with_match(
                         drift,
                         *market_index,
                         *subaccount,
@@ -2485,7 +2454,8 @@ impl PrimaryLiquidationStrategy {
                         cu_limit,
                         slot,
                         pyth_update,
-                    );
+                    )
+                    .await;
                     return;
                 }
             }
@@ -2516,9 +2486,8 @@ impl PrimaryLiquidationStrategy {
         };
 
         // Check available collateral
-        let collateral_map = collateral_info_per_subaccount;
-        let Some(collateral_info) = collateral_map.get(&subaccount) else {
-            log::warn!(target: TARGET, "no collateral info for keeper subaccount");
+        let Some(free_collateral) = self.free_collateral_per_subaccount.get(&subaccount) else {
+            log::warn!(target: TARGET, "no free collateral for keeper subaccount");
             return;
         };
 
@@ -2547,7 +2516,7 @@ impl PrimaryLiquidationStrategy {
 
         let method = Self::decide_perp_method(
             pos.quote_asset_amount.try_into().unwrap(),
-            collateral_info.free,
+            *free_collateral,
             collateral_required,
             makers.is_some(),
         );
@@ -2559,7 +2528,7 @@ impl PrimaryLiquidationStrategy {
 
         match method {
             LiquidationType::PerpWithFill => {
-                try_liquidate_with_match(
+                Self::try_liquidate_with_match(
                     drift,
                     pos.market_index,
                     *subaccount,
@@ -2570,7 +2539,8 @@ impl PrimaryLiquidationStrategy {
                     cu_limit,
                     slot,
                     pyth_update,
-                );
+                )
+                .await;
             }
             LiquidationType::PerpTakeover => {
                 let Some(subaccount) = Self::find_best_subaccount_for_liquidation(
@@ -2578,28 +2548,30 @@ impl PrimaryLiquidationStrategy {
                     subaccounts,
                     true,
                     false,
-                    &collateral_map,
+                    &self.free_collateral_per_subaccount,
                     collateral_required,
                 ) else {
                     log::warn!(target: TARGET, "no subaccount available for takeover");
                     return;
                 };
 
-                let selected_collateral_info = collateral_map
-                    .get(&subaccount)
-                    .expect("subaccount has collateral info");
+                let Some(free_collateral) = self.free_collateral_per_subaccount.get(&subaccount)
+                else {
+                    log::warn!(target: TARGET, "no free collateral for subaccount");
+                    return;
+                };
 
-                let base_amount_to_liquidate =
-                    if selected_collateral_info.free >= collateral_required as i128 {
-                        pos.base_asset_amount.unsigned_abs()
-                    } else {
-                        let scaled_collateral = (collateral_info.free as f64 * 0.9) as u128;
-                        let scale_factor = scaled_collateral as f64 / collateral_required as f64;
-                        (pos.base_asset_amount.unsigned_abs() as f64 * scale_factor) as u64
-                    };
+                let base_amount_to_liquidate = if *free_collateral >= collateral_required {
+                    pos.base_asset_amount.unsigned_abs()
+                } else {
+                    let scaled_collateral = (*free_collateral as f64 * 0.9) as u128;
+                    let scale_factor = scaled_collateral as f64 / collateral_required as f64;
+                    (pos.base_asset_amount.unsigned_abs() as f64 * scale_factor) as u64
+                };
 
-                try_liquidate_with_collateral(
-                    drift,
+                Self::try_liquidate_with_collateral(
+                    &self,
+                    &drift,
                     pos.market_index,
                     subaccount,
                     liquidatee,
@@ -2609,7 +2581,8 @@ impl PrimaryLiquidationStrategy {
                     cu_limit,
                     slot,
                     pyth_update,
-                );
+                )
+                .await;
             }
             _ => {
                 log::info!(target: TARGET, "skipping liquidation for {:?}", liquidatee);
@@ -2838,21 +2811,107 @@ impl PrimaryLiquidationStrategy {
             //     "sending spot liq tx: {liquidatee:?}, asset={asset_market_index}, liability={}",
             //     liability_market_index
             // );
-            tx_sender.send_tx(
+
+            tx_sender
+                .send_tx(
+                    tx,
+                    TxIntent::LiquidateSpot {
+                        asset_market_index,
+                        liability_market_index,
+                        liquidatee,
+                        slot,
+                    },
+                    cu_limit as u64,
+                )
+                .await;
+        }
+    }
+
+    async fn try_liquidate_perp_pnl_for_deposit(
+        &self,
+        drift: &DriftClient,
+        subaccount: Pubkey,
+        liquidatee: Pubkey,
+        liability: &PositionInfo,
+        asset: &PositionInfo,
+        liq_amount: u128,
+        tx_sender: TxSender,
+        priority_fee: u64,
+        cu_limit: u32,
+        slot: u64,
+        pyth_price_update: Option<PythPriceUpdate>,
+    ) {
+        let keeper_account = match drift.try_get_account::<User>(&subaccount) {
+            Ok(data) => data,
+            Err(_) => {
+                log::warn!(target: TARGET, "keeper account not found");
+                return;
+            }
+        };
+
+        let liquidatee_account = match drift.try_get_account::<User>(&liquidatee) {
+            Ok(data) => data,
+            Err(_) => {
+                log::warn!(target: TARGET, "liquidatee account not found");
+                return;
+            }
+        };
+
+        let mut tx_builder = TransactionBuilder::new(
+            drift.program_data(),
+            subaccount,
+            std::borrow::Cow::Owned(keeper_account),
+            false,
+        )
+        .with_priority_fee(priority_fee, Some(cu_limit));
+
+        if let Some(ref update) = pyth_price_update {
+            tx_builder =
+                tx_builder.post_pyth_lazer_oracle_update(&[update.feed_id], &update.message);
+        }
+
+        tx_builder = tx_builder.liquidate_perp_pnl_for_deposit(
+            &liquidatee_account,
+            liability.market_index,
+            asset.market_index,
+            drift_rs::types::u128::from(liq_amount),
+            None,
+        );
+
+        let tx = tx_builder.build();
+
+        match tx_sender
+            .send_tx(
                 tx,
-                TxIntent::LiquidateSpot {
-                    asset_market_index,
-                    liability_market_index,
+                TxIntent::LiquidatePerpPnlForDeposit {
+                    perp_market_index: liability.market_index,
+                    spot_market_index: asset.market_index,
                     liquidatee,
                     slot,
                 },
                 cu_limit as u64,
-            );
-        }
+            )
+            .await
+        {
+            Some(sig) => {
+                self.txs_in_flight
+                    .entry(subaccount)
+                    .or_insert_with(HashSet::new)
+                    .insert(sig);
+
+                self.tx_sig_to_collateral.insert(sig, liq_amount);
+
+                if let Some(mut free) = self.free_collateral_per_subaccount.get_mut(&subaccount) {
+                    *free = free.saturating_sub(liq_amount);
+                }
+            }
+            None => return,
+        };
     }
 
     /// Attempt perp pnl for deposit liquidation
     async fn liquidate_perp_pnl_for_deposit(
+        &self,
         drift: &DriftClient,
         market_state: Arc<RwLock<MarketState>>,
         subaccounts: &[Pubkey],
@@ -2864,7 +2923,6 @@ impl PrimaryLiquidationStrategy {
         cu_limit: u32,
         slot: u64,
         pyth_price_update: Option<PythPriceUpdate>,
-        collateral_info_per_subaccount: Arc<DashMap<Pubkey, CollateralInfo>>,
     ) {
         let net_collateral_req = Self::calculate_net_collateral_requirement(
             liability.collateral_required.unsigned_abs(),
@@ -2873,23 +2931,22 @@ impl PrimaryLiquidationStrategy {
             Arc::clone(&market_state),
         );
 
-        let collateral_map = collateral_info_per_subaccount;
         let Some(subaccount) = Self::find_best_subaccount_for_liquidation(
             drift,
             subaccounts,
             false,
             true,
-            &collateral_map,
+            &self.free_collateral_per_subaccount,
             net_collateral_req.max(0) as u128,
         ) else {
             return;
         };
 
-        let Some(collateral_info) = collateral_map.get(&subaccount) else {
+        let Some(free_collateral) = self.free_collateral_per_subaccount.get(&subaccount) else {
             return;
         };
 
-        let available = collateral_info.free;
+        let available = *free_collateral as i128;
         let tolerance = available / 10;
 
         let params = Self::extract_collateral_params(Arc::clone(&market_state), &liability, &asset);
@@ -2914,7 +2971,8 @@ impl PrimaryLiquidationStrategy {
             return;
         }
 
-        try_liquidate_perp_pnl_for_deposit(
+        Self::try_liquidate_perp_pnl_for_deposit(
+            &self,
             drift,
             subaccount,
             liquidatee,
@@ -2926,11 +2984,95 @@ impl PrimaryLiquidationStrategy {
             cu_limit,
             slot,
             pyth_price_update,
+        )
+        .await;
+    }
+
+    async fn try_liquidate_borrow_for_perp_pnl(
+        &self,
+        drift: &DriftClient,
+        subaccount: Pubkey,
+        liquidatee: Pubkey,
+        liability: &PositionInfo,
+        asset: &PositionInfo,
+        liq_amount: u128,
+        tx_sender: TxSender,
+        priority_fee: u64,
+        cu_limit: u32,
+        slot: u64,
+        pyth_price_update: Option<PythPriceUpdate>,
+    ) {
+        let keeper_account = match drift.try_get_account::<User>(&subaccount) {
+            Ok(data) => data,
+            Err(_) => {
+                log::warn!(target: TARGET, "keeper account not found");
+                return;
+            }
+        };
+
+        let liquidatee_account = match drift.try_get_account::<User>(&liquidatee) {
+            Ok(data) => data,
+            Err(_) => {
+                log::warn!(target: TARGET, "liquidatee account not found");
+                return;
+            }
+        };
+
+        let mut tx_builder = TransactionBuilder::new(
+            drift.program_data(),
+            subaccount,
+            std::borrow::Cow::Owned(keeper_account),
+            false,
+        )
+        .with_priority_fee(priority_fee, Some(cu_limit));
+
+        if let Some(ref update) = pyth_price_update {
+            tx_builder =
+                tx_builder.post_pyth_lazer_oracle_update(&[update.feed_id], &update.message);
+        }
+
+        tx_builder = tx_builder.liquidate_borrow_for_perp_pnl(
+            &liquidatee_account,
+            asset.market_index,
+            liability.market_index,
+            drift_rs::types::u128::from(liq_amount),
+            None,
         );
+
+        let tx = tx_builder.build();
+
+        match tx_sender
+            .send_tx(
+                tx,
+                TxIntent::LiquidateBorrowForPerpPnl {
+                    perp_market_index: asset.market_index,
+                    spot_market_index: liability.market_index,
+                    liquidatee,
+                    slot,
+                },
+                cu_limit as u64,
+            )
+            .await
+        {
+            Some(sig) => {
+                self.txs_in_flight
+                    .entry(subaccount)
+                    .or_insert_with(HashSet::new)
+                    .insert(sig);
+
+                self.tx_sig_to_collateral.insert(sig, liq_amount);
+
+                if let Some(mut free) = self.free_collateral_per_subaccount.get_mut(&subaccount) {
+                    *free = free.saturating_sub(liq_amount);
+                }
+            }
+            None => return,
+        };
     }
 
     /// Attempt borrow for perp pnl liquidation
     async fn liquidate_borrow_for_perp_pnl(
+        &self,
         drift: &DriftClient,
         market_state: Arc<RwLock<MarketState>>,
         subaccounts: &[Pubkey],
@@ -2942,7 +3084,6 @@ impl PrimaryLiquidationStrategy {
         cu_limit: u32,
         slot: u64,
         pyth_price_update: Option<PythPriceUpdate>,
-        collateral_info_per_subaccount: Arc<DashMap<Pubkey, CollateralInfo>>,
     ) {
         let net_collateral_req = Self::calculate_net_collateral_requirement(
             liability.base_amount.unsigned_abs() as u128,
@@ -2951,20 +3092,22 @@ impl PrimaryLiquidationStrategy {
             Arc::clone(&market_state),
         );
 
-        let collateral_map = collateral_info_per_subaccount;
         let Some(subaccount) = Self::find_best_subaccount_for_liquidation(
             drift,
             subaccounts,
             true,
             false,
-            &collateral_map,
+            &self.free_collateral_per_subaccount,
             net_collateral_req.max(0) as u128,
         ) else {
             return;
         };
 
-        let collateral_info = collateral_map.get(&subaccount).unwrap();
-        let available = collateral_info.free;
+        let Some(free_collateral) = self.free_collateral_per_subaccount.get(&subaccount) else {
+            return;
+        };
+
+        let available = *free_collateral as i128;
         let tolerance = available / 10;
 
         let params = Self::extract_collateral_params(Arc::clone(&market_state), &liability, &asset);
@@ -2989,7 +3132,8 @@ impl PrimaryLiquidationStrategy {
             return;
         }
 
-        try_liquidate_borrow_for_perp_pnl(
+        Self::try_liquidate_borrow_for_perp_pnl(
+            &self,
             drift,
             subaccount,
             liquidatee,
@@ -3001,7 +3145,61 @@ impl PrimaryLiquidationStrategy {
             cu_limit,
             slot,
             pyth_price_update,
-        );
+        )
+        .await;
+    }
+
+    // Settle perp pnl
+    async fn settle_perp_pnl(
+        drift: &DriftClient,
+        subaccount: Pubkey,
+        liquidatee: Pubkey,
+        market_indexes: &[u16],
+        tx_sender: TxSender,
+        priority_fee: u64,
+        cu_limit: u32,
+    ) {
+        let keeper_account = match drift.try_get_account::<User>(&subaccount) {
+            Ok(data) => data,
+            Err(_) => {
+                log::warn!(target: TARGET, "keeper account not found");
+                return;
+            }
+        };
+
+        let liquidatee_account = match drift.try_get_account::<User>(&liquidatee) {
+            Ok(data) => data,
+            Err(_) => {
+                log::warn!(target: TARGET, "liquidatee account not found");
+                return;
+            }
+        };
+
+        let mut tx_builder = TransactionBuilder::new(
+            drift.program_data(),
+            subaccount,
+            std::borrow::Cow::Owned(keeper_account),
+            false,
+        )
+        .with_priority_fee(priority_fee, Some(cu_limit));
+
+        for &market_index in market_indexes {
+            tx_builder =
+                tx_builder.settle_pnl(market_index, Some(&liquidatee), Some(&liquidatee_account));
+        }
+
+        let tx = tx_builder.build();
+
+        tx_sender
+            .send_tx(
+                tx,
+                TxIntent::SettlePnl {
+                    market_index: market_indexes[0],
+                    subaccount: liquidatee,
+                },
+                cu_limit as u64,
+            )
+            .await;
     }
 }
 
@@ -3015,7 +3213,6 @@ impl LiquidationStrategy for PrimaryLiquidationStrategy {
         cu_limit: u32,
         slot: u64,
         pyth_price_update: Option<PythPriceUpdate>,
-        collateral_info_per_subaccount: Arc<DashMap<Pubkey, CollateralInfo>>,
         status: UserMarginStatus,
     ) -> futures_util::future::BoxFuture<'a, ()> {
         let perp_positions = Self::get_perp_positions_info(
@@ -3042,93 +3239,109 @@ impl LiquidationStrategy for PrimaryLiquidationStrategy {
             return async {}.boxed();
         };
 
-        let liq_type = Self::decide_liquidation_type(&liability, asset.as_ref());
+        let has_pnl_only = perp_positions
+            .iter()
+            .any(|p| p.base_amount == 0 && p.quote_amount != 0 && p.is_asset)
+            && spot_positions.iter().filter(|s| !s.is_asset).count() == 0;
 
-        match liq_type {
-            LiquidationType::PerpTakeover | LiquidationType::PerpWithFill => {
-                Self::liquidate_perp(
-                    &self.drift,
-                    self.dlob,
-                    Arc::clone(&self.market_state),
-                    Arc::clone(&self.metrics),
-                    self.subaccounts.as_slice(),
-                    liquidatee,
-                    Arc::clone(&user_account),
-                    tx_sender.clone(),
-                    priority_fee,
-                    cu_limit,
-                    slot,
-                    pyth_price_update,
-                    collateral_info_per_subaccount,
-                    &status,
-                );
-                async {}.boxed()
-            }
-            LiquidationType::SpotForSpot => {
-                if self.use_spot_liquidation {
-                    Self::liquidate_spot(
-                        self.drift.clone(),
-                        Arc::clone(&self.metrics),
+        let liq_type = Self::decide_liquidation_type(&liability, asset.as_ref(), has_pnl_only);
+
+        async move {
+            match liq_type {
+                LiquidationType::SettlePnl => {
+                    let markets: Vec<u16> = perp_positions
+                        .iter()
+                        .filter(|p| p.base_amount == 0 && p.quote_amount != 0 && p.is_asset)
+                        .map(|p| p.market_index)
+                        .collect();
+
+                    Self::settle_perp_pnl(
+                        &self.drift,
+                        self.subaccounts[0],
+                        liquidatee,
+                        &markets,
+                        tx_sender,
+                        priority_fee,
+                        cu_limit,
+                    )
+                    .await;
+                }
+                LiquidationType::PerpTakeover | LiquidationType::PerpWithFill => {
+                    Self::liquidate_perp(
+                        &self,
+                        &self.drift,
+                        self.dlob,
                         Arc::clone(&self.market_state),
+                        Arc::clone(&self.metrics),
                         self.subaccounts.as_slice(),
                         liquidatee,
-                        user_account,
+                        Arc::clone(&user_account),
                         tx_sender.clone(),
                         priority_fee,
-                        400_000,
-                        slot,
-                    )
-                    .boxed()
-                } else {
-                    async {}.boxed()
-                }
-            }
-            LiquidationType::PerpPnlForDeposit => {
-                if let Some(asset) = asset {
-                    Self::liquidate_perp_pnl_for_deposit(
-                        &self.drift,
-                        Arc::clone(&self.market_state),
-                        self.subaccounts.as_slice(),
-                        liquidatee,
-                        liability,
-                        asset,
-                        tx_sender,
-                        priority_fee,
                         cu_limit,
                         slot,
                         pyth_price_update,
-                        collateral_info_per_subaccount,
-                    )
-                    .boxed()
-                } else {
-                    async {}.boxed()
+                        &status,
+                    ).await;
+                }
+                LiquidationType::SpotForSpot => {
+                    if self.use_spot_liquidation {
+                        Self::liquidate_spot(
+                            self.drift.clone(),
+                            Arc::clone(&self.metrics),
+                            Arc::clone(&self.market_state),
+                            self.subaccounts.as_slice(),
+                            liquidatee,
+                            user_account,
+                            tx_sender.clone(),
+                            priority_fee,
+                            400_000,
+                            slot,
+                        ).await;
+                    }
+                }
+                LiquidationType::PerpPnlForDeposit => {
+                    if let Some(asset) = asset {
+                        Self::liquidate_perp_pnl_for_deposit(
+                            &self,
+                            &self.drift,
+                            Arc::clone(&self.market_state),
+                            self.subaccounts.as_slice(),
+                            liquidatee,
+                            liability,
+                            asset,
+                            tx_sender,
+                            priority_fee,
+                            cu_limit,
+                            slot,
+                            pyth_price_update,
+                        )
+                        .await;
+                    }
+                }
+                LiquidationType::BorrowForPerpPnl => {
+                    if let Some(asset) = asset {
+                        Self::liquidate_borrow_for_perp_pnl(
+                            &self,
+                            &self.drift,
+                            Arc::clone(&self.market_state),
+                            self.subaccounts.as_slice(),
+                            liquidatee,
+                            liability,
+                            asset,
+                            tx_sender,
+                            priority_fee,
+                            cu_limit,
+                            slot,
+                            pyth_price_update,
+                        )
+                        .await;
+                    }
+                }
+                LiquidationType::Skip => {
+                    log::info!(target: TARGET, "skipping liquidation for {:?}: insufficient collateral", liquidatee);
                 }
             }
-            LiquidationType::BorrowForPerpPnl => {
-                if let Some(asset) = asset {
-                    Self::liquidate_borrow_for_perp_pnl(
-                        &self.drift,
-                        Arc::clone(&self.market_state),
-                        self.subaccounts.as_slice(),
-                        liquidatee,
-                        liability,
-                        asset,
-                        tx_sender,
-                        priority_fee,
-                        cu_limit,
-                        slot,
-                        pyth_price_update,
-                        collateral_info_per_subaccount,
-                    )
-                    .boxed()
-                } else {
-                    async {}.boxed()
-                }
-            }
-            LiquidationType::Skip => {
-                log::info!(target: TARGET, "skipping liquidation for {:?}: insufficient collateral", liquidatee);
-                async {}.boxed()
-            }
-        }
+        }.boxed()
     }
 }

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -24,7 +24,7 @@ use drift_rs::{
     math::{
         constants::{
             BASE_PRECISION, BASE_PRECISION_U64, MARGIN_PRECISION_U128, PRICE_PRECISION,
-            QUOTE_PRECISION, SPOT_WEIGHT_PRECISION, SPOT_WEIGHT_PRECISION_U128,
+            QUOTE_PRECISION, SPOT_WEIGHT_PRECISION_U128,
         },
         liquidation::{calculate_collateral, CollateralInfo},
     },
@@ -460,8 +460,13 @@ impl LiquidatorBot {
             PriorityFeeSubscriber::new(drift.rpc().url(), &market_pubkeys);
         let priority_fee_subscriber = priority_fee_subscriber.subscribe();
 
-        let keeper_subaccount = drift.wallet.sub_account(config.sub_account_id);
-        log::info!(target: TARGET, "liquidator 🫠 bot started: authority={:?}, subaccount={:?}", drift.wallet.authority(), keeper_subaccount);
+        let subaccounts: Vec<Pubkey> = config
+            .get_subaccounts()
+            .iter()
+            .map(|id| drift.wallet.sub_account(*id))
+            .collect();
+
+        log::info!(target: TARGET, "liquidator 🫠 bot started: authority={:?}, subaccount={:?}", drift.wallet.authority(), subaccounts);
 
         drift.subscribe_blockhashes().await.expect("subscribed");
         let dlob_notifier = dlob.spawn_notifier();
@@ -537,12 +542,11 @@ impl LiquidatorBot {
         )>(102400);
         spawn_liquidation_worker(
             tx_sender.clone(),
-            // TODO: apply your own liquidation strategy here
             Arc::new(PrimaryLiquidationStrategy {
                 dlob,
                 drift: drift.clone(),
                 market_state: Arc::clone(&market_state),
-                keeper_subaccount,
+                subaccounts: subaccounts.clone(),
                 metrics: Arc::clone(&metrics),
                 use_spot_liquidation: config.use_spot_liquidation,
             }),
@@ -553,12 +557,6 @@ impl LiquidatorBot {
         );
 
         log::info!(target: TARGET, "spawned liquidation worker");
-        // Spawn derisk loop
-        let subaccounts: Vec<Pubkey> = config
-            .get_subaccounts()
-            .iter()
-            .map(|id| Wallet::derive_user_account(&drift.wallet.authority(), *id))
-            .collect();
 
         spawn_derisk_loop(
             drift.clone(),
@@ -567,6 +565,8 @@ impl LiquidatorBot {
             Arc::clone(&priority_fee_subscriber),
             cu_limit,
         );
+
+        log::info!(target: TARGET, "spawned derisk worker");
 
         LiquidatorBot {
             drift,
@@ -856,7 +856,7 @@ impl LiquidatorBot {
             if oracle_update {
                 let _high_risk_count = high_risk.len();
 
-                let t0 = current_time_millis();
+                let _t0 = current_time_millis();
                 let mut liquidatable_users = Vec::new();
 
                 // Update dashboard state
@@ -980,7 +980,7 @@ impl LiquidatorBot {
                 // );
 
                 // Update high_risk set synchronously but quickly (just remove safe users)
-                let t0 = current_time_millis();
+                let _t0 = current_time_millis();
                 high_risk.retain(|pubkey| {
                     if let Some(user_meta) = users.get(pubkey) {
                         // Log staleness but still check margin status
@@ -1228,6 +1228,8 @@ fn derisk_subaccount(
             cu_limit as u64,
         );
     }
+
+    // TODO: Add spot derisking, swap any position back to USDC using jupiter/titan
 }
 
 fn spawn_derisk_loop(
@@ -1294,35 +1296,6 @@ async fn get_collateral_info_per_subaccount(
         }
     }
     collateral_info_per_subaccount
-}
-
-fn calculate_perp_collateral_requirement(
-    market_state: Arc<RwLock<MarketState>>,
-    market_index: u16,
-    base_asset_amount: i64,
-) -> Option<u128> {
-    let state = market_state.read().unwrap().load();
-
-    let perp_market = state.perp_markets.get(&market_index)?;
-    let oracle = state.perp_oracle_prices.get(&market_index)?;
-
-    let margin_ratio = perp_market
-        .get_margin_ratio(
-            base_asset_amount.unsigned_abs() as u128,
-            MarginRequirementType::Initial,
-            false,
-        )
-        .ok()?;
-
-    let collateral = (base_asset_amount.abs() as u128)
-        .saturating_mul(oracle.price as u128)
-        .saturating_mul(QUOTE_PRECISION)
-        .saturating_mul(margin_ratio as u128)
-        .saturating_div(MARGIN_PRECISION_U128)
-        .saturating_div(PRICE_PRECISION)
-        .saturating_div(BASE_PRECISION);
-
-    Some(collateral)
 }
 
 fn on_transaction_update_fn(
@@ -1617,7 +1590,7 @@ fn try_liquidate_with_collateral(
 
 fn try_liquidate_perp_pnl_for_deposit(
     drift: &DriftClient,
-    keeper_subaccount: Pubkey,
+    subaccount: Pubkey,
     liquidatee: Pubkey,
     liability: &PositionInfo,
     asset: &PositionInfo,
@@ -1627,7 +1600,7 @@ fn try_liquidate_perp_pnl_for_deposit(
     slot: u64,
     pyth_price_update: Option<PythPriceUpdate>,
 ) {
-    let keeper_account = match drift.try_get_account::<User>(&keeper_subaccount) {
+    let keeper_account = match drift.try_get_account::<User>(&subaccount) {
         Ok(data) => data,
         Err(_) => {
             log::warn!(target: TARGET, "keeper account not found");
@@ -1645,7 +1618,7 @@ fn try_liquidate_perp_pnl_for_deposit(
 
     let mut tx_builder = TransactionBuilder::new(
         drift.program_data(),
-        keeper_subaccount,
+        subaccount,
         std::borrow::Cow::Owned(keeper_account),
         false,
     )
@@ -1679,7 +1652,7 @@ fn try_liquidate_perp_pnl_for_deposit(
 
 fn try_liquidate_borrow_for_perp_pnl(
     drift: &DriftClient,
-    keeper_subaccount: Pubkey,
+    subaccount: Pubkey,
     liquidatee: Pubkey,
     liability: &PositionInfo,
     asset: &PositionInfo,
@@ -1689,7 +1662,7 @@ fn try_liquidate_borrow_for_perp_pnl(
     slot: u64,
     pyth_price_update: Option<PythPriceUpdate>,
 ) {
-    let keeper_account = match drift.try_get_account::<User>(&keeper_subaccount) {
+    let keeper_account = match drift.try_get_account::<User>(&subaccount) {
         Ok(data) => data,
         Err(_) => {
             log::warn!(target: TARGET, "keeper account not found");
@@ -1707,7 +1680,7 @@ fn try_liquidate_borrow_for_perp_pnl(
 
     let mut tx_builder = TransactionBuilder::new(
         drift.program_data(),
-        keeper_subaccount,
+        subaccount,
         std::borrow::Cow::Owned(keeper_account),
         false,
     )
@@ -1867,7 +1840,7 @@ pub struct PrimaryLiquidationStrategy {
     pub drift: DriftClient,
     pub dlob: &'static DLOB,
     pub market_state: Arc<RwLock<MarketState>>,
-    pub keeper_subaccount: Pubkey,
+    pub subaccounts: Vec<Pubkey>,
     pub metrics: Arc<Metrics>,
     pub use_spot_liquidation: bool,
 }
@@ -1876,17 +1849,18 @@ impl PrimaryLiquidationStrategy {
     /// Liquidation policy: Prefer takeover for large positions (≥$10k), use makers for small positions,
     /// fallback to takeover when no makers available. Skip if no makers and insufficient collateral.
     fn decide_perp_method(
-        base_asset_amount_to_liquidate: u64,
+        base_asset_amount: u64,
+        oracle_price: u64,
         collateral_available: i128,
         collateral_required: u128,
         has_makers: bool,
     ) -> LiquidationType {
-        const LARGE_POSITION_THRESHOLD: u64 = 10_000 * BASE_PRECISION_U64;
+        const POSITION_AMOUNT_THRESHOLD: u64 = 1_000 * BASE_PRECISION_U64;
 
-        let is_large_position = base_asset_amount_to_liquidate >= LARGE_POSITION_THRESHOLD;
+        let is_small_position = base_asset_amount * oracle_price <= POSITION_AMOUNT_THRESHOLD;
         let can_afford_takeover = collateral_available >= collateral_required as i128;
 
-        if is_large_position && can_afford_takeover {
+        if is_small_position && can_afford_takeover {
             LiquidationType::PerpTakeover
         } else if has_makers {
             LiquidationType::PerpWithFill
@@ -1908,6 +1882,126 @@ impl PrimaryLiquidationStrategy {
             (MarketType::Spot, Some(MarketType::Spot)) => LiquidationType::SpotForSpot,
             _ => LiquidationType::Skip,
         }
+    }
+
+    fn calculate_perp_collateral_requirement(
+        market_state: Arc<RwLock<MarketState>>,
+        market_index: u16,
+        base_asset_amount: i64,
+    ) -> Option<u128> {
+        let state = market_state.read().unwrap().load();
+
+        let perp_market = state.perp_markets.get(&market_index)?;
+        let oracle = state.perp_oracle_prices.get(&market_index)?;
+
+        let margin_ratio = perp_market
+            .get_margin_ratio(
+                base_asset_amount.unsigned_abs() as u128,
+                MarginRequirementType::Initial,
+                false,
+            )
+            .ok()?;
+
+        let collateral = (base_asset_amount.abs() as u128)
+            .saturating_mul(oracle.price as u128)
+            .saturating_mul(QUOTE_PRECISION)
+            .saturating_mul(margin_ratio as u128)
+            .saturating_div(MARGIN_PRECISION_U128)
+            .saturating_div(PRICE_PRECISION)
+            .saturating_div(BASE_PRECISION);
+
+        Some(collateral)
+    }
+
+    fn calculate_net_collateral_requirement(
+        liability_size: u128,
+        liability: &PositionInfo,
+        asset: &PositionInfo,
+        market_state: Arc<RwLock<MarketState>>,
+    ) -> i128 {
+        let state = market_state.read().unwrap().load();
+
+        let (liability_oracle, liability_precision) = if liability.market_type == MarketType::Spot {
+            let oracle = state
+                .spot_oracle_prices
+                .get(&liability.market_index)
+                .expect("liability oracle");
+            let market = state
+                .spot_markets
+                .get(&liability.market_index)
+                .expect("liability market");
+            (oracle, 10_u128.pow(market.decimals))
+        } else {
+            let oracle = state.spot_oracle_prices.get(&0).expect("USDC oracle");
+            (oracle, QUOTE_PRECISION)
+        };
+
+        let (asset_oracle, asset_precision) = if asset.market_type == MarketType::Spot {
+            let oracle = state
+                .spot_oracle_prices
+                .get(&asset.market_index)
+                .expect("asset oracle");
+            let market = state
+                .spot_markets
+                .get(&asset.market_index)
+                .expect("asset market");
+            (oracle, 10_u128.pow(market.decimals))
+        } else {
+            let oracle = state.spot_oracle_prices.get(&0).expect("USDC oracle");
+            (oracle, QUOTE_PRECISION)
+        };
+
+        let asset_amount_back_in_tokens = liability_size
+            .saturating_mul(liability_oracle.price as u128)
+            .saturating_div(asset_oracle.price as u128)
+            .saturating_mul(asset_precision)
+            .saturating_div(liability_precision);
+
+        let (asset_weight, asset_weight_precision) = if asset.market_type == MarketType::Spot {
+            let spot_market = state
+                .spot_markets
+                .get(&asset.market_index)
+                .expect("asset spot market");
+            (
+                spot_market.initial_asset_weight as u128,
+                SPOT_WEIGHT_PRECISION_U128,
+            )
+        } else {
+            (SPOT_WEIGHT_PRECISION_U128, SPOT_WEIGHT_PRECISION_U128)
+        };
+
+        let asset_amount_back_in_collateral = asset_amount_back_in_tokens
+            .saturating_mul(asset_oracle.price as u128)
+            .saturating_mul(QUOTE_PRECISION)
+            .saturating_mul(asset_weight)
+            .saturating_div(asset_weight_precision)
+            .saturating_div(asset_precision)
+            .saturating_div(PRICE_PRECISION);
+
+        let liability_collateral_impact = if liability.market_type == MarketType::Spot {
+            let spot_market = state
+                .spot_markets
+                .get(&liability.market_index)
+                .expect("liability spot market");
+            liability_size
+                .saturating_mul(liability_oracle.price as u128)
+                .saturating_div(PRICE_PRECISION)
+                .saturating_mul(QUOTE_PRECISION)
+                .saturating_div(liability_precision)
+                .saturating_mul(spot_market.initial_liability_weight as u128)
+                .saturating_div(SPOT_WEIGHT_PRECISION_U128)
+        } else {
+            liability
+                .collateral_required
+                .unsigned_abs()
+                .min(liability_size)
+        };
+
+        let net_impact = liability_collateral_impact.saturating_sub(
+            asset_amount_back_in_collateral.min(asset.collateral_required.unsigned_abs()),
+        );
+
+        net_impact as i128
     }
 
     /// Calculate collateral requirement for all perp positions
@@ -2032,6 +2126,63 @@ impl PrimaryLiquidationStrategy {
         Some((largest_liability, best_asset))
     }
 
+    /// Returns the subaccount with most free collateral that has position room
+    fn find_best_subaccount_for_liquidation(
+        drift: &DriftClient,
+        subaccounts: &[Pubkey],
+        needs_perp_room: bool,
+        needs_spot_room: bool,
+        collateral_info_per_subaccount: &HashMap<Pubkey, CollateralInfo>,
+        min_collateral_required: u128,
+    ) -> Option<Pubkey> {
+        let mut candidates: Vec<(Pubkey, i128)> = subaccounts
+            .iter()
+            .filter_map(|&subaccount| {
+                let collateral_info = collateral_info_per_subaccount.get(&subaccount)?;
+
+                if collateral_info.free < min_collateral_required as i128 {
+                    return None;
+                }
+
+                let user = drift.try_get_account::<User>(&subaccount).ok()?;
+
+                if needs_perp_room {
+                    let active_perp_positions = user
+                        .perp_positions
+                        .iter()
+                        .filter(|p| p.base_asset_amount != 0 || p.quote_asset_amount != 0)
+                        .count();
+
+                    if active_perp_positions >= 8 {
+                        return None;
+                    }
+                }
+
+                if needs_spot_room {
+                    let active_spot_positions = user
+                        .spot_positions
+                        .iter()
+                        .filter(|p| !p.is_available())
+                        .count();
+
+                    if active_spot_positions >= 8 {
+                        return None;
+                    }
+                }
+
+                Some((subaccount, collateral_info.free))
+            })
+            .collect();
+
+        if candidates.is_empty() {
+            return None;
+        }
+
+        candidates.sort_by_key(|&(_, free_collateral)| std::cmp::Reverse(free_collateral));
+
+        Some(candidates[0].0)
+    }
+
     /// Find top makers for a perp position
     fn find_top_makers(
         drift: &DriftClient,
@@ -2091,7 +2242,7 @@ impl PrimaryLiquidationStrategy {
         dlob: &'static DLOB,
         market_state: Arc<RwLock<MarketState>>,
         metrics: Arc<Metrics>,
-        keeper_subaccount: Pubkey,
+        subaccounts: &[Pubkey],
         liquidatee: Pubkey,
         user_account: Arc<User>,
         tx_sender: TxSender,
@@ -2102,6 +2253,11 @@ impl PrimaryLiquidationStrategy {
         collateral_info_per_subaccount: Arc<RwLock<HashMap<Pubkey, CollateralInfo>>>,
         status: &UserMarginStatus,
     ) {
+        let Some(keeper_subaccount) = subaccounts.first() else {
+            log::warn!(target: TARGET, "no subaccount configured");
+            return;
+        };
+
         // Check isolated liquidations first
         for (market_index, iso_status) in &status.isolated {
             if *iso_status == MarginStatus::Liquidatable {
@@ -2146,7 +2302,7 @@ impl PrimaryLiquidationStrategy {
                     try_liquidate_with_match(
                         drift,
                         *market_index,
-                        keeper_subaccount,
+                        *keeper_subaccount,
                         liquidatee,
                         makers.as_slice(),
                         tx_sender,
@@ -2175,7 +2331,7 @@ impl PrimaryLiquidationStrategy {
         };
 
         // Calculate collateral required
-        let Some(collateral_required) = calculate_perp_collateral_requirement(
+        let Some(collateral_required) = Self::calculate_perp_collateral_requirement(
             Arc::clone(&market_state),
             pos.market_index,
             pos.base_asset_amount,
@@ -2191,21 +2347,6 @@ impl PrimaryLiquidationStrategy {
             return;
         };
 
-        // Calculate amount to be liquidated (full or partial)
-        let base_asset_amount_to_be_liquidated =
-            if collateral_info.free >= collateral_required as i128 {
-                pos.base_asset_amount.unsigned_abs()
-            } else {
-                // Scale down to 90% of available collateral
-                let scale_factor = (collateral_info.free as f64 / collateral_required as f64) * 0.9;
-                (pos.base_asset_amount.unsigned_abs() as f64 * scale_factor) as u64
-            };
-
-        metrics
-            .liquidation_attempts
-            .with_label_values(&["perp"])
-            .inc();
-
         // Get oracle price and pyth update once
         let oracle_price = {
             let state = market_state.read().unwrap();
@@ -2218,8 +2359,6 @@ impl PrimaryLiquidationStrategy {
             }
         };
 
-        let pyth_update = pyth_price_update.filter(|update| update.price != oracle_price);
-
         // Find makers and decide method
         let makers = Self::find_top_makers(
             drift,
@@ -2229,19 +2368,27 @@ impl PrimaryLiquidationStrategy {
             pos.base_asset_amount,
         );
 
+        let pyth_update = pyth_price_update.filter(|update| update.price != oracle_price);
+
         let method = Self::decide_perp_method(
-            base_asset_amount_to_be_liquidated,
+            pos.base_asset_amount.try_into().unwrap(),
+            oracle_price,
             collateral_info.free,
             collateral_required,
             makers.is_some(),
         );
+
+        metrics
+            .liquidation_attempts
+            .with_label_values(&["perp"])
+            .inc();
 
         match method {
             LiquidationType::PerpWithFill => {
                 try_liquidate_with_match(
                     drift,
                     pos.market_index,
-                    keeper_subaccount,
+                    *keeper_subaccount,
                     liquidatee,
                     makers.unwrap().as_slice(),
                     tx_sender,
@@ -2252,12 +2399,37 @@ impl PrimaryLiquidationStrategy {
                 );
             }
             LiquidationType::PerpTakeover => {
+                let Some(subaccount) = Self::find_best_subaccount_for_liquidation(
+                    drift,
+                    subaccounts,
+                    true,
+                    false,
+                    &collateral_map,
+                    collateral_required,
+                ) else {
+                    log::warn!(target: TARGET, "no subaccount available for takeover");
+                    return;
+                };
+
+                let selected_collateral_info = collateral_map
+                    .get(&subaccount)
+                    .expect("subaccount has collateral info");
+
+                let base_amount_to_liquidate =
+                    if selected_collateral_info.free >= collateral_required as i128 {
+                        pos.base_asset_amount.unsigned_abs()
+                    } else {
+                        let scaled_collateral = (collateral_info.free as f64 * 0.9) as u128;
+                        let scale_factor = scaled_collateral as f64 / collateral_required as f64;
+                        (pos.base_asset_amount.unsigned_abs() as f64 * scale_factor) as u64
+                    };
+
                 try_liquidate_with_collateral(
                     drift,
                     pos.market_index,
-                    keeper_subaccount,
+                    subaccount,
                     liquidatee,
-                    base_asset_amount_to_be_liquidated,
+                    base_amount_to_liquidate,
                     tx_sender,
                     priority_fee,
                     cu_limit,
@@ -2276,7 +2448,7 @@ impl PrimaryLiquidationStrategy {
         drift: DriftClient,
         metrics: Arc<Metrics>,
         market_state: Arc<RwLock<MarketState>>,
-        keeper_subaccount: Pubkey,
+        subaccounts: &[Pubkey],
         liquidatee: Pubkey,
         user_account: Arc<User>,
         tx_sender: TxSender,
@@ -2285,6 +2457,10 @@ impl PrimaryLiquidationStrategy {
         slot: u64,
     ) {
         let authority = drift.wallet.authority();
+        let Some(keeper_subaccount) = subaccounts.first() else {
+            log::warn!(target: TARGET, "no subaccount configured");
+            return;
+        };
 
         for pos in user_account
             .spot_positions
@@ -2447,7 +2623,7 @@ impl PrimaryLiquidationStrategy {
             let tx = if use_titan {
                 TransactionBuilder::new(
                     drift.program_data(),
-                    keeper_subaccount,
+                    *keeper_subaccount,
                     std::borrow::Cow::Owned(keeper_account_data),
                     false,
                 )
@@ -2466,7 +2642,7 @@ impl PrimaryLiquidationStrategy {
             } else {
                 TransactionBuilder::new(
                     drift.program_data(),
-                    keeper_subaccount,
+                    *keeper_subaccount,
                     std::borrow::Cow::Owned(keeper_account_data),
                     false,
                 )
@@ -2499,6 +2675,104 @@ impl PrimaryLiquidationStrategy {
                 cu_limit as u64,
             );
         }
+    }
+
+    /// Attempt perp pnl for deposit liquidation
+    async fn liquidate_perp_pnl_for_deposit(
+        drift: &DriftClient,
+        market_state: Arc<RwLock<MarketState>>,
+        subaccounts: &[Pubkey],
+        liquidatee: Pubkey,
+        liability: PositionInfo,
+        asset: PositionInfo,
+        tx_sender: TxSender,
+        priority_fee: u64,
+        cu_limit: u32,
+        slot: u64,
+        pyth_price_update: Option<PythPriceUpdate>,
+        collateral_info_per_subaccount: Arc<RwLock<HashMap<Pubkey, CollateralInfo>>>,
+    ) {
+        let net_collateral_req = Self::calculate_net_collateral_requirement(
+            liability.collateral_required.unsigned_abs(),
+            &liability,
+            &asset,
+            Arc::clone(&market_state),
+        );
+
+        let collateral_map = collateral_info_per_subaccount.read().unwrap();
+        let Some(subaccount) = Self::find_best_subaccount_for_liquidation(
+            drift,
+            subaccounts,
+            false,
+            true,
+            &collateral_map,
+            net_collateral_req.max(0) as u128,
+        ) else {
+            log::warn!(target: TARGET, "no subaccount available for perp pnl for deposit");
+            return;
+        };
+
+        try_liquidate_perp_pnl_for_deposit(
+            drift,
+            subaccount,
+            liquidatee,
+            &liability,
+            &asset,
+            tx_sender,
+            priority_fee,
+            cu_limit,
+            slot,
+            pyth_price_update,
+        );
+    }
+
+    /// Attempt borrow for perp pnl liquidation
+    async fn liquidate_borrow_for_perp_pnl(
+        drift: &DriftClient,
+        market_state: Arc<RwLock<MarketState>>,
+        subaccounts: &[Pubkey],
+        liquidatee: Pubkey,
+        liability: PositionInfo,
+        asset: PositionInfo,
+        tx_sender: TxSender,
+        priority_fee: u64,
+        cu_limit: u32,
+        slot: u64,
+        pyth_price_update: Option<PythPriceUpdate>,
+        collateral_info_per_subaccount: Arc<RwLock<HashMap<Pubkey, CollateralInfo>>>,
+    ) {
+        let net_collateral_req = Self::calculate_net_collateral_requirement(
+            liability.base_amount.unsigned_abs() as u128,
+            &liability,
+            &asset,
+            Arc::clone(&market_state),
+        );
+
+        let collateral_map = collateral_info_per_subaccount.read().unwrap();
+        let Some(subaccount) = Self::find_best_subaccount_for_liquidation(
+            drift,
+            subaccounts,
+            true,
+            false,
+            &collateral_map,
+            net_collateral_req.max(0) as u128,
+        ) else {
+            log::warn!(target: TARGET, "no subaccount available for borrow for perp pnl");
+            return;
+        };
+
+        try_liquidate_borrow_for_perp_pnl(
+            drift,
+            subaccount,
+            liquidatee,
+            &liability,
+            &asset,
+            tx_sender,
+            priority_fee,
+            cu_limit,
+            slot,
+            pyth_price_update,
+        );
     }
 }
 
@@ -2541,7 +2815,7 @@ impl LiquidationStrategy for PrimaryLiquidationStrategy {
                     self.dlob,
                     Arc::clone(&self.market_state),
                     Arc::clone(&self.metrics),
-                    self.keeper_subaccount,
+                    self.subaccounts.as_slice(),
                     liquidatee,
                     Arc::clone(&user_account),
                     tx_sender.clone(),
@@ -2560,7 +2834,7 @@ impl LiquidationStrategy for PrimaryLiquidationStrategy {
                         self.drift.clone(),
                         Arc::clone(&self.metrics),
                         Arc::clone(&self.market_state),
-                        self.keeper_subaccount,
+                        self.subaccounts.as_slice(),
                         liquidatee,
                         user_account,
                         tx_sender.clone(),
@@ -2575,37 +2849,45 @@ impl LiquidationStrategy for PrimaryLiquidationStrategy {
             }
             LiquidationType::PerpPnlForDeposit => {
                 if let Some(asset) = asset {
-                    try_liquidate_perp_pnl_for_deposit(
+                    Self::liquidate_perp_pnl_for_deposit(
                         &self.drift,
-                        self.keeper_subaccount,
+                        Arc::clone(&self.market_state),
+                        self.subaccounts.as_slice(),
                         liquidatee,
-                        &liability,
-                        &asset,
+                        liability,
+                        asset,
                         tx_sender,
                         priority_fee,
                         cu_limit,
                         slot,
                         pyth_price_update,
-                    );
+                        collateral_info_per_subaccount,
+                    )
+                    .boxed()
+                } else {
+                    async {}.boxed()
                 }
-                async {}.boxed()
             }
             LiquidationType::BorrowForPerpPnl => {
                 if let Some(asset) = asset {
-                    try_liquidate_borrow_for_perp_pnl(
+                    Self::liquidate_borrow_for_perp_pnl(
                         &self.drift,
-                        self.keeper_subaccount,
+                        Arc::clone(&self.market_state),
+                        self.subaccounts.as_slice(),
                         liquidatee,
-                        &liability,
-                        &asset,
+                        liability,
+                        asset,
                         tx_sender,
                         priority_fee,
                         cu_limit,
                         slot,
                         pyth_price_update,
-                    );
+                        collateral_info_per_subaccount,
+                    )
+                    .boxed()
+                } else {
+                    async {}.boxed()
                 }
-                async {}.boxed()
             }
             LiquidationType::Skip => {
                 log::info!(target: TARGET, "skipping liquidation for {:?}: insufficient collateral", liquidatee);

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -630,8 +630,6 @@ impl LiquidatorBot {
             'pyth: loop {
                 match pyth_price_feed.try_recv() {
                     Ok(update) => {
-                        log::info!(target: TARGET, "processing pyth m={}", update.market_id);
-
                         let market_id = update.market_id;
                         let price = update.price;
 
@@ -653,16 +651,11 @@ impl LiquidatorBot {
                         log::error!(target: TARGET, "pyth price feed disconnected");
                         return;
                     }
-                    Err(TryRecvError::Empty) => {
-                        log::info!(target: TARGET, "pyth empty");
-                        break 'pyth;
-                    }
+                    Err(TryRecvError::Empty) => break 'pyth,
                 }
             }
 
-            log::info!(target: TARGET, "calling events_rx.recv_many");
             events_rx.recv_many(&mut event_buffer, 64).await;
-            log::info!(target: TARGET, "got {} events", event_buffer.len());
             for event in event_buffer.drain(..) {
                 match event {
                     GrpcEvent::UserUpdate {
@@ -891,7 +884,7 @@ impl LiquidatorBot {
                     )) {
                         Ok(()) => {}
                         Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                            log::warn!(
+                            log::debug!(
                                 target: TARGET,
                                 "liquidation channel full, dropping liquidation for {:?}",
                                 pubkey
@@ -1069,7 +1062,7 @@ impl LiquidatorBot {
                         )) {
                             Ok(()) => {}
                             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                                log::warn!(
+                                log::debug!(
                                     target: TARGET,
                                     "liquidation channel full, dropping liquidation for {:?}",
                                     pubkey
@@ -1356,7 +1349,7 @@ fn spawn_liquidation_worker(
                 .get(&liquidatee)
                 .is_some_and(|last| slot.abs_diff(*last) < LIQUIDATION_SLOT_RATE_LIMIT)
             {
-                log::warn!(target: TARGET, "rate limited liquidation for {:?} (current: {})", liquidatee, slot);
+                log::debug!(target: TARGET, "rate limited liquidation for {:?} (current: {})", liquidatee, slot);
                 continue;
             } else {
                 rate_limit.insert(liquidatee, slot);

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -2381,6 +2381,7 @@ impl PrimaryLiquidationStrategy {
         subaccount: Pubkey,
         liquidatee_subaccount: Pubkey,
         base_asset_amount: u64,
+        collateral_required: u128,
         tx_sender: TxSender,
         priority_fee: u64,
         cu_limit: u32,
@@ -2452,7 +2453,7 @@ impl PrimaryLiquidationStrategy {
                     .insert(sig, (base_asset_amount as u128, current_time_millis()));
 
                 if let Some(mut free) = self.free_collateral_per_subaccount.get_mut(&subaccount) {
-                    *free = free.saturating_sub(base_asset_amount as u128);
+                    *free = free.saturating_sub(collateral_required);
                 }
             }
             None => return,
@@ -2655,6 +2656,7 @@ impl PrimaryLiquidationStrategy {
                     subaccount,
                     liquidatee,
                     base_amount_to_liquidate,
+                    collateral_required,
                     tx_sender,
                     priority_fee,
                     cu_limit,

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -514,7 +514,7 @@ impl LiquidatorBot {
             u64,
             Option<PythPriceUpdate>,
             UserMarginStatus,
-        )>(10240);
+        )>(102400);
         spawn_liquidation_worker(
             tx_sender.clone(),
             // TODO: apply your own liquidation strategy here
@@ -1147,7 +1147,7 @@ async fn setup_grpc(
     transaction_tx: TxSender,
     market_ids: Vec<MarketId>,
 ) -> tokio::sync::mpsc::Receiver<GrpcEvent> {
-    let (tx, rx) = tokio::sync::mpsc::channel(10240);
+    let (tx, rx) = tokio::sync::mpsc::channel(102400);
 
     let _ = tokio::try_join!(
         crate::filler::sync_stats_accounts(&drift),

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -17,7 +17,7 @@ use tokio::sync::mpsc::error::TryRecvError;
 
 use drift_rs::{
     dlob::{DLOBNotifier, DLOB},
-    ffi::{OraclePriceData, SimplifiedMarginCalculation},
+    ffi::{calculate_claimable_pnl, OraclePriceData, SimplifiedMarginCalculation},
     grpc::{grpc_subscriber::AccountFilter, TransactionUpdate},
     jupiter::SwapMode,
     market_state::MarketStateData,
@@ -27,6 +27,7 @@ use drift_rs::{
             QUOTE_PRECISION, SPOT_WEIGHT_PRECISION_U128,
         },
         liquidation::{calculate_collateral, CollateralInfo},
+        tiers::perp_tier_is_as_safe_as,
     },
     priority_fee_subscriber::PriorityFeeSubscriber,
     titan,
@@ -1456,7 +1457,7 @@ async fn setup_grpc(
 fn try_liquidate_with_match(
     drift: &DriftClient,
     market_index: u16,
-    keeper_subaccount: Pubkey,
+    subaccount: Pubkey,
     liquidatee_subaccount: Pubkey,
     top_makers: &[User],
     tx_sender: TxSender,
@@ -1470,9 +1471,9 @@ fn try_liquidate_with_match(
         return;
     }
 
-    let keeper_account_data = drift.try_get_account::<User>(&keeper_subaccount);
+    let keeper_account_data = drift.try_get_account::<User>(&subaccount);
     if keeper_account_data.is_err() {
-        log::debug!(target: TARGET, "keeper acc lookup failed={keeper_subaccount:?}");
+        log::debug!(target: TARGET, "keeper acc lookup failed={subaccount:?}");
         return;
     }
     let liquidatee_subaccount_data = drift.try_get_account::<User>(&liquidatee_subaccount);
@@ -1483,7 +1484,7 @@ fn try_liquidate_with_match(
 
     let mut tx_builder = TransactionBuilder::new(
         drift.program_data(),
-        keeper_subaccount,
+        subaccount,
         std::borrow::Cow::Owned(keeper_account_data.unwrap()),
         false,
     )
@@ -1526,7 +1527,7 @@ fn try_liquidate_with_match(
 fn try_liquidate_with_collateral(
     drift: &DriftClient,
     market_index: u16,
-    keeper_subaccount: Pubkey,
+    subaccount: Pubkey,
     liquidatee_subaccount: Pubkey,
     base_asset_amount: u64,
     tx_sender: TxSender,
@@ -1535,9 +1536,9 @@ fn try_liquidate_with_collateral(
     slot: u64,
     pyth_price_update: Option<PythPriceUpdate>,
 ) {
-    let keeper_account_data = drift.try_get_account::<User>(&keeper_subaccount);
+    let keeper_account_data = drift.try_get_account::<User>(&subaccount);
     if keeper_account_data.is_err() {
-        log::debug!(target: TARGET, "keeper acc lookup failed={keeper_subaccount:?}");
+        log::debug!(target: TARGET, "keeper acc lookup failed={subaccount:?}");
         return;
     }
     let liquidatee_subaccount_data = drift.try_get_account::<User>(&liquidatee_subaccount);
@@ -1548,7 +1549,7 @@ fn try_liquidate_with_collateral(
 
     let mut tx_builder = TransactionBuilder::new(
         drift.program_data(),
-        keeper_subaccount,
+        subaccount,
         std::borrow::Cow::Owned(keeper_account_data.unwrap()),
         false,
     )
@@ -1594,6 +1595,7 @@ fn try_liquidate_perp_pnl_for_deposit(
     liquidatee: Pubkey,
     liability: &PositionInfo,
     asset: &PositionInfo,
+    liq_amount: u128,
     tx_sender: TxSender,
     priority_fee: u64,
     cu_limit: u32,
@@ -1632,7 +1634,7 @@ fn try_liquidate_perp_pnl_for_deposit(
         &liquidatee_account,
         liability.market_index,
         asset.market_index,
-        drift_rs::types::u128::from(liability.collateral_required.unsigned_abs()),
+        drift_rs::types::u128::from(liq_amount),
         None,
     );
 
@@ -1656,6 +1658,7 @@ fn try_liquidate_borrow_for_perp_pnl(
     liquidatee: Pubkey,
     liability: &PositionInfo,
     asset: &PositionInfo,
+    liq_amount: u128,
     tx_sender: TxSender,
     priority_fee: u64,
     cu_limit: u32,
@@ -1694,7 +1697,7 @@ fn try_liquidate_borrow_for_perp_pnl(
         &liquidatee_account,
         asset.market_index,
         liability.market_index,
-        drift_rs::types::u128::from(liability.base_amount.unsigned_abs() as u128),
+        drift_rs::types::u128::from(liq_amount),
         None,
     );
 
@@ -2004,6 +2007,45 @@ impl PrimaryLiquidationStrategy {
         net_impact as i128
     }
 
+    /// finds the max liquidation amount whose collateral impact fits within available collateral,
+    /// allowing unused collateral up to `tolerance`.
+    fn find_max_liq_amount<F>(
+        max_amount: u128,
+        available_collateral: i128,
+        tolerance: i128,
+        impact_fn: F,
+    ) -> u128
+    where
+        F: Fn(u128) -> i128,
+    {
+        let mut low = 0u128;
+        let mut high = max_amount;
+        let mut best = 0u128;
+
+        while low <= high {
+            let mid = (low + high) / 2;
+            let impact = impact_fn(mid);
+            let difference = available_collateral - impact;
+
+            if difference < 0 {
+                if mid == 0 {
+                    break;
+                }
+                high = mid - 1;
+            } else {
+                best = mid;
+
+                if difference > tolerance {
+                    low = mid + 1;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        best
+    }
+
     /// Calculate collateral requirement for all perp positions
     fn get_perp_positions_info(
         market_state: Arc<RwLock<MarketState>>,
@@ -2018,30 +2060,49 @@ impl PrimaryLiquidationStrategy {
                 let perp_market = state.perp_markets.get(&pos.market_index)?;
                 let oracle = state.perp_oracle_prices.get(&pos.market_index)?;
 
-                let margin_ratio = perp_market
-                    .get_margin_ratio(
-                        pos.base_asset_amount.unsigned_abs() as u128,
-                        MarginRequirementType::Initial,
-                        false,
-                    )
-                    .ok()?;
+                if pos.base_asset_amount == 0 && pos.quote_asset_amount != 0 && pos.lp_shares == 0 {
+                    let usdc = state.spot_markets.get(&0)?;
 
-                let collateral = (pos.base_asset_amount.abs() as u128)
-                    .saturating_mul(oracle.price as u128)
-                    .saturating_mul(QUOTE_PRECISION)
-                    .saturating_mul(margin_ratio as u128)
-                    .saturating_div(MARGIN_PRECISION_U128)
-                    .saturating_div(PRICE_PRECISION)
-                    .saturating_div(BASE_PRECISION);
+                    let claimable_pnl_available =
+                        match calculate_claimable_pnl(perp_market, usdc, pos, oracle.price) {
+                            Ok(pnl) => pnl.abs(),
+                            Err(_) => 0,
+                        };
 
-                Some(PositionInfo {
-                    market_type: MarketType::Perp,
-                    market_index: pos.market_index,
-                    is_asset: pos.quote_asset_amount > 0,
-                    collateral_required: collateral as i128,
-                    base_amount: pos.base_asset_amount,
-                    quote_amount: pos.quote_asset_amount,
-                })
+                    Some(PositionInfo {
+                        market_type: MarketType::Perp,
+                        market_index: pos.market_index,
+                        is_asset: claimable_pnl_available > 0,
+                        collateral_required: claimable_pnl_available as i128,
+                        base_amount: 0,
+                        quote_amount: pos.quote_asset_amount,
+                    })
+                } else {
+                    let margin_ratio = perp_market
+                        .get_margin_ratio(
+                            pos.base_asset_amount.unsigned_abs() as u128,
+                            MarginRequirementType::Initial,
+                            false,
+                        )
+                        .ok()?;
+
+                    let collateral = (pos.base_asset_amount.abs() as u128)
+                        .saturating_mul(oracle.price as u128)
+                        .saturating_mul(QUOTE_PRECISION)
+                        .saturating_mul(margin_ratio as u128)
+                        .saturating_div(MARGIN_PRECISION_U128)
+                        .saturating_div(PRICE_PRECISION)
+                        .saturating_div(BASE_PRECISION);
+
+                    Some(PositionInfo {
+                        market_type: MarketType::Perp,
+                        market_index: pos.market_index,
+                        is_asset: pos.quote_asset_amount > 0,
+                        collateral_required: collateral as i128,
+                        base_amount: pos.base_asset_amount,
+                        quote_amount: pos.quote_asset_amount,
+                    })
+                }
             })
             .collect()
     }
@@ -2089,11 +2150,46 @@ impl PrimaryLiquidationStrategy {
             .collect()
     }
 
+    // Port of  https://github.com/drift-labs/protocol-v2/blob/master/sdk/src/user.ts#L3941-L3971
+    fn get_safest_tiers(user_account: &User, market_state: Arc<RwLock<MarketState>>) -> (u8, u8) {
+        let mut safest_perp_tier = 4;
+        let mut safest_spot_tier = 4;
+
+        let state = market_state.read().unwrap().load();
+
+        for perp_position in user_account
+            .perp_positions
+            .iter()
+            .filter(|p| !p.is_available())
+        {
+            if let Some(perp_market) = state.perp_markets.get(&perp_position.market_index) {
+                safest_perp_tier = safest_perp_tier.min(perp_market.contract_tier.to_number());
+            }
+        }
+
+        for spot_position in user_account
+            .spot_positions
+            .iter()
+            .filter(|p| !p.is_available() && p.balance_type != SpotBalanceType::Deposit)
+        {
+            if let Some(spot_market) = state.spot_markets.get(&spot_position.market_index) {
+                safest_spot_tier = safest_spot_tier.min(spot_market.asset_tier.to_number());
+            }
+        }
+
+        (safest_perp_tier, safest_spot_tier)
+    }
+
     /// Pick the largest liability and best matching asset
     fn pick_best_asset_liability_combo(
+        market_state: Arc<RwLock<MarketState>>,
         perp_positions: &[PositionInfo],
         spot_positions: &[PositionInfo],
+        safest_perp_tier: u8,
+        safest_spot_tier: u8,
     ) -> Option<(PositionInfo, Option<PositionInfo>)> {
+        let state = market_state.read().unwrap().load();
+
         let mut liabilities: Vec<PositionInfo> = perp_positions
             .iter()
             .chain(spot_positions)
@@ -2120,7 +2216,21 @@ impl PrimaryLiquidationStrategy {
                 .cmp(&a.collateral_required.abs())
         });
 
-        let largest_liability = liabilities.first()?.clone();
+        let largest_liability = liabilities.into_iter().find(|liability| {
+            if liability.market_type == MarketType::Spot {
+                true
+            } else {
+                match state.perp_markets.get(&liability.market_index) {
+                    Some(perp_market) => perp_tier_is_as_safe_as(
+                        perp_market.contract_tier.to_number(),
+                        safest_perp_tier,
+                        safest_spot_tier,
+                    ),
+                    None => false,
+                }
+            }
+        })?;
+
         let best_asset = assets.first().cloned();
 
         Some((largest_liability, best_asset))
@@ -2253,7 +2363,7 @@ impl PrimaryLiquidationStrategy {
         collateral_info_per_subaccount: Arc<RwLock<HashMap<Pubkey, CollateralInfo>>>,
         status: &UserMarginStatus,
     ) {
-        let Some(keeper_subaccount) = subaccounts.first() else {
+        let Some(subaccount) = subaccounts.first() else {
             log::warn!(target: TARGET, "no subaccount configured");
             return;
         };
@@ -2302,7 +2412,7 @@ impl PrimaryLiquidationStrategy {
                     try_liquidate_with_match(
                         drift,
                         *market_index,
-                        *keeper_subaccount,
+                        *subaccount,
                         liquidatee,
                         makers.as_slice(),
                         tx_sender,
@@ -2342,7 +2452,7 @@ impl PrimaryLiquidationStrategy {
 
         // Check available collateral
         let collateral_map = collateral_info_per_subaccount.read().unwrap();
-        let Some(collateral_info) = collateral_map.get(&keeper_subaccount) else {
+        let Some(collateral_info) = collateral_map.get(&subaccount) else {
             log::warn!(target: TARGET, "no collateral info for keeper subaccount");
             return;
         };
@@ -2388,7 +2498,7 @@ impl PrimaryLiquidationStrategy {
                 try_liquidate_with_match(
                     drift,
                     pos.market_index,
-                    *keeper_subaccount,
+                    *subaccount,
                     liquidatee,
                     makers.unwrap().as_slice(),
                     tx_sender,
@@ -2457,7 +2567,7 @@ impl PrimaryLiquidationStrategy {
         slot: u64,
     ) {
         let authority = drift.wallet.authority();
-        let Some(keeper_subaccount) = subaccounts.first() else {
+        let Some(subaccount) = subaccounts.first() else {
             log::warn!(target: TARGET, "no subaccount configured");
             return;
         };
@@ -2523,10 +2633,10 @@ impl PrimaryLiquidationStrategy {
             );
 
             // Fetch accounts once
-            let keeper_account_data = match drift.try_get_account::<User>(&keeper_subaccount) {
+            let keeper_account_data = match drift.try_get_account::<User>(&subaccount) {
                 Ok(data) => data,
                 Err(_) => {
-                    log::info!(target: TARGET, "keeper account not found: {:?}", &keeper_subaccount);
+                    log::info!(target: TARGET, "keeper account not found: {:?}", &subaccount);
                     continue;
                 }
             };
@@ -2623,7 +2733,7 @@ impl PrimaryLiquidationStrategy {
             let tx = if use_titan {
                 TransactionBuilder::new(
                     drift.program_data(),
-                    *keeper_subaccount,
+                    *subaccount,
                     std::borrow::Cow::Owned(keeper_account_data),
                     false,
                 )
@@ -2642,7 +2752,7 @@ impl PrimaryLiquidationStrategy {
             } else {
                 TransactionBuilder::new(
                     drift.program_data(),
-                    *keeper_subaccount,
+                    *subaccount,
                     std::borrow::Cow::Owned(keeper_account_data),
                     false,
                 )
@@ -2692,7 +2802,7 @@ impl PrimaryLiquidationStrategy {
         pyth_price_update: Option<PythPriceUpdate>,
         collateral_info_per_subaccount: Arc<RwLock<HashMap<Pubkey, CollateralInfo>>>,
     ) {
-        let net_collateral_req = Self::calculate_net_collateral_requirement(
+        let full_net_req = Self::calculate_net_collateral_requirement(
             liability.collateral_required.unsigned_abs(),
             &liability,
             &asset,
@@ -2706,11 +2816,39 @@ impl PrimaryLiquidationStrategy {
             false,
             true,
             &collateral_map,
-            net_collateral_req.max(0) as u128,
+            full_net_req.max(0) as u128,
         ) else {
-            log::warn!(target: TARGET, "no subaccount available for perp pnl for deposit");
             return;
         };
+
+        let Some(collateral_info) = collateral_map.get(&subaccount) else {
+            return;
+        };
+
+        let available = collateral_info.free;
+        let tolerance = available / 10;
+
+        let liq_amount = if full_net_req <= available {
+            liability.collateral_required.unsigned_abs()
+        } else {
+            Self::find_max_liq_amount(
+                liability.collateral_required.unsigned_abs(),
+                available,
+                tolerance,
+                |size| {
+                    Self::calculate_net_collateral_requirement(
+                        size,
+                        &liability,
+                        &asset,
+                        Arc::clone(&market_state),
+                    )
+                },
+            )
+        };
+
+        if liq_amount == 0 {
+            return;
+        }
 
         try_liquidate_perp_pnl_for_deposit(
             drift,
@@ -2718,6 +2856,7 @@ impl PrimaryLiquidationStrategy {
             liquidatee,
             &liability,
             &asset,
+            liq_amount,
             tx_sender,
             priority_fee,
             cu_limit,
@@ -2757,9 +2896,30 @@ impl PrimaryLiquidationStrategy {
             &collateral_map,
             net_collateral_req.max(0) as u128,
         ) else {
-            log::warn!(target: TARGET, "no subaccount available for borrow for perp pnl");
             return;
         };
+
+        let collateral_info = collateral_map.get(&subaccount).unwrap();
+        let available = collateral_info.free;
+        let tolerance = available / 10;
+
+        let max_liq_amount = Self::find_max_liq_amount(
+            liability.base_amount.unsigned_abs() as u128,
+            available,
+            tolerance,
+            |size| {
+                Self::calculate_net_collateral_requirement(
+                    size,
+                    &liability,
+                    &asset,
+                    Arc::clone(&market_state),
+                )
+            },
+        );
+
+        if max_liq_amount == 0 {
+            return;
+        }
 
         try_liquidate_borrow_for_perp_pnl(
             drift,
@@ -2767,6 +2927,7 @@ impl PrimaryLiquidationStrategy {
             liquidatee,
             &liability,
             &asset,
+            max_liq_amount,
             tx_sender,
             priority_fee,
             cu_limit,
@@ -2799,9 +2960,16 @@ impl LiquidationStrategy for PrimaryLiquidationStrategy {
             &user_account.spot_positions,
         );
 
-        let Some((liability, asset)) =
-            Self::pick_best_asset_liability_combo(&perp_positions, &spot_positions)
-        else {
+        let (safest_perp_tier, safest_spot_tier) =
+            Self::get_safest_tiers(&user_account, Arc::clone(&self.market_state));
+
+        let Some((liability, asset)) = Self::pick_best_asset_liability_combo(
+            Arc::clone(&self.market_state),
+            &perp_positions,
+            &spot_positions,
+            safest_perp_tier,
+            safest_spot_tier,
+        ) else {
             log::warn!(target: TARGET, "no liquidatable positions for {:?}", liquidatee);
             return async {}.boxed();
         };

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -794,17 +794,17 @@ impl LiquidatorBot {
                 let mut liquidatable_users = Vec::new();
 
                 // Update dashboard state
-                update_dashboard_state(
-                    drift,
-                    &self.dashboard_state,
-                    &users,
-                    &oracle_prices,
-                    &high_risk,
-                    current_slot,
-                    self.market_state,
-                    liquidation_margin_buffer_ratio,
-                )
-                .await;
+                // update_dashboard_state(
+                //     drift,
+                //     &self.dashboard_state,
+                //     &users,
+                //     &oracle_prices,
+                //     &high_risk,
+                //     current_slot,
+                //     self.market_state,
+                //     liquidation_margin_buffer_ratio,
+                // )
+                // .await;
 
                 for pubkey in &high_risk {
                     if let Some(user_meta) = users.get(&pubkey) {
@@ -971,17 +971,17 @@ impl LiquidatorBot {
                 let mut newly_high_risk = 0;
 
                 // Update dashboard state periodically
-                update_dashboard_state(
-                    drift,
-                    &self.dashboard_state,
-                    &users,
-                    &oracle_prices,
-                    &high_risk,
-                    current_slot,
-                    self.market_state,
-                    liquidation_margin_buffer_ratio,
-                )
-                .await;
+                // update_dashboard_state(
+                //     drift,
+                //     &self.dashboard_state,
+                //     &users,
+                //     &oracle_prices,
+                //     &high_risk,
+                //     current_slot,
+                //     self.market_state,
+                //     liquidation_margin_buffer_ratio,
+                // )
+                // .await;
 
                 for (pubkey, user_meta) in users.iter() {
                     if high_risk.contains(pubkey) {

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -36,6 +36,7 @@ use crate::{
     filler::{TxSender, TxWorker},
     http::{
         DashboardState, DashboardStateRef, HighRiskUser, MarginStatus, Metrics, OraclePriceInfo,
+        UserMarginStatus,
     },
     util::{PythPriceUpdate, TxIntent},
     Config, UseMarkets,
@@ -191,10 +192,13 @@ async fn update_dashboard_state(
                 0.0
             };
 
-            let status = match check_margin_status(&margin_info) {
-                MarginStatus::Liquidatable => MarginStatus::Liquidatable,
-                MarginStatus::HighRisk => MarginStatus::HighRisk,
-                MarginStatus::Safe => continue, // Shouldn't happen if in high_risk set
+            let status = check_margin_status(&margin_info);
+            let display_status = if status.is_liquidatable() {
+                MarginStatus::Liquidatable
+            } else if status.is_at_risk() {
+                MarginStatus::HighRisk
+            } else {
+                continue;
             };
 
             let mut positions = Vec::new();
@@ -240,7 +244,7 @@ async fn update_dashboard_state(
                 margin_requirement: margin_info.margin_requirement,
                 free_margin,
                 free_margin_ratio,
-                status,
+                status: display_status,
                 last_updated_slot: user_meta.last_updated_slot,
                 last_updated_ms: user_meta.last_updated_timestamp_ms,
                 positions,
@@ -281,26 +285,48 @@ async fn update_dashboard_state(
 }
 
 /// Check margin status (liquidatable, high-risk, or safe)
-fn check_margin_status(margin_info: &SimplifiedMarginCalculation) -> MarginStatus {
+fn check_margin_status(margin_info: &SimplifiedMarginCalculation) -> UserMarginStatus {
     const LIQUIDATION_BUFFER: f64 = 1.0;
+    let mut isolated = Vec::with_capacity(8);
 
-    let buffered_margin_req = (margin_info.margin_requirement as f64 * LIQUIDATION_BUFFER) as i128;
-
-    if margin_info.total_collateral < buffered_margin_req {
-        return MarginStatus::Liquidatable;
-    }
-
-    // Calculate free margin
-    let free_margin = margin_info.total_collateral - margin_info.margin_requirement as i128;
-
-    // User is high-risk if free margin < 20% of margin requirement
-    if margin_info.margin_requirement > 0 && free_margin > 0 {
-        let free_margin_ratio = free_margin as f64 / margin_info.margin_requirement as f64;
-        if free_margin_ratio < HIGH_RISK_FREE_MARGIN_RATIO {
-            return MarginStatus::HighRisk;
+    // Check isolated positions
+    for calc in &margin_info.isolated_margin_calculations {
+        if !calc.is_empty() {
+            let buffered_iso_margin_req =
+                (calc.margin_requirement as f64 * LIQUIDATION_BUFFER) as i128;
+            if calc.total_collateral < buffered_iso_margin_req {
+                isolated.push((calc.market_index, MarginStatus::Liquidatable));
+            } else {
+                let free_margin = calc.total_collateral - calc.margin_requirement as i128;
+                if calc.margin_requirement > 0 && free_margin > 0 {
+                    let free_margin_ratio = free_margin as f64 / calc.margin_requirement as f64;
+                    if free_margin_ratio < HIGH_RISK_FREE_MARGIN_RATIO {
+                        isolated.push((calc.market_index, MarginStatus::HighRisk));
+                    }
+                }
+            }
         }
     }
-    MarginStatus::Safe
+
+    // Check cross margin
+    let buffered_margin_req = (margin_info.margin_requirement as f64 * LIQUIDATION_BUFFER) as i128;
+    let cross = if margin_info.total_collateral < buffered_margin_req {
+        MarginStatus::Liquidatable
+    } else {
+        let free_margin = margin_info.total_collateral - margin_info.margin_requirement as i128;
+        if margin_info.margin_requirement > 0 && free_margin > 0 {
+            let free_margin_ratio = free_margin as f64 / margin_info.margin_requirement as f64;
+            if free_margin_ratio < HIGH_RISK_FREE_MARGIN_RATIO {
+                MarginStatus::HighRisk
+            } else {
+                MarginStatus::Safe
+            }
+        } else {
+            MarginStatus::Safe
+        }
+    };
+
+    UserMarginStatus { cross, isolated }
 }
 
 /// Trait for pluggable liquidation strategies
@@ -315,6 +341,7 @@ pub trait LiquidationStrategy {
         cu_limit: u32,
         slot: u64,
         pyth_price_update: Option<PythPriceUpdate>,
+        status: UserMarginStatus,
     ) -> futures_util::future::BoxFuture<'a, ()>;
 }
 
@@ -348,7 +375,14 @@ pub struct LiquidatorBot {
     /// receives new updates from grpc
     events_rx: tokio::sync::mpsc::Receiver<GrpcEvent>,
     /// sends liquidatable accounts to work thread (pubkey, user, slot, timestamp_ms, pyth price)
-    liq_tx: tokio::sync::mpsc::Sender<(Pubkey, User, u64, u64, Option<PythPriceUpdate>)>,
+    liq_tx: tokio::sync::mpsc::Sender<(
+        Pubkey,
+        User,
+        u64,
+        u64,
+        Option<PythPriceUpdate>,
+        UserMarginStatus,
+    )>,
     pyth_price_feed: Option<tokio::sync::mpsc::Receiver<PythPriceUpdate>>,
     /// Dashboard state for HTTP API
     dashboard_state: DashboardStateRef,
@@ -464,8 +498,14 @@ impl LiquidatorBot {
         log::info!(target: TARGET, "subscribed pyth price feeds");
 
         // start liquidation worker
-        let (liq_tx, liq_rx) =
-            tokio::sync::mpsc::channel::<(Pubkey, User, u64, u64, Option<PythPriceUpdate>)>(1024);
+        let (liq_tx, liq_rx) = tokio::sync::mpsc::channel::<(
+            Pubkey,
+            User,
+            u64,
+            u64,
+            Option<PythPriceUpdate>,
+            UserMarginStatus,
+        )>(1024);
         spawn_liquidation_worker(
             tx_sender.clone(),
             // TODO: apply your own liquidation strategy here
@@ -550,12 +590,11 @@ impl LiquidatorBot {
                         },
                     );
                     // Check margin status and add to high-risk set if needed
-                    match check_margin_status(&margin_info) {
-                        MarginStatus::Liquidatable | MarginStatus::HighRisk => {
-                            high_risk.insert(*pubkey);
-                            initial_high_risk_count += 1;
-                        }
-                        MarginStatus::Safe => {}
+                    let status = check_margin_status(&margin_info);
+
+                    if status.is_at_risk(){
+                        high_risk.insert(*pubkey);
+                        initial_high_risk_count += 1;
                     }
                 }
             });
@@ -673,17 +712,14 @@ impl LiquidatorBot {
                                 high_risk.remove(&pubkey);
                                 users.remove(&pubkey);
                             } else {
-                                match check_margin_status(&margin_info) {
-                                    MarginStatus::Liquidatable => {
-                                        // log::debug!(target: TARGET, "found liquidatable user: {pubkey:?}, margin:{margin_info:?}");
-                                        high_risk.insert(pubkey);
-                                    }
-                                    MarginStatus::HighRisk => {
-                                        high_risk.insert(pubkey);
-                                    }
-                                    MarginStatus::Safe => {
-                                        high_risk.remove(&pubkey);
-                                    }
+                                let status = check_margin_status(&margin_info);
+                                if status.is_liquidatable() {
+                                    // log::debug!(target: TARGET, "found liquidatable user: {pubkey:?}, margin:{margin_info:?}");
+                                    high_risk.insert(pubkey);
+                                } else if status.is_at_risk() {
+                                    high_risk.insert(pubkey);
+                                } else {
+                                    high_risk.remove(&pubkey);
                                 }
                             }
                         }
@@ -793,18 +829,16 @@ impl LiquidatorBot {
                             }
                         };
 
-                        match check_margin_status(&margin_info) {
-                            MarginStatus::Liquidatable => {
-                                // log::debug!(target: TARGET, "found liquidatable user: {pubkey:?}, margin:{margin_info:?}");
-                                liquidatable_users.push((pubkey, user_meta.user.clone()));
-                            }
-                            _ => {}
+                        let status = check_margin_status(&margin_info);
+                        if status.is_liquidatable() {
+                            // log::debug!(target: TARGET, "found liquidatable user: {pubkey:?}, margin:{margin_info:?}");
+                            liquidatable_users.push((pubkey, user_meta.user.clone(), status));
                         }
                     }
                 }
 
                 // Send liquidations outside the loop
-                for (pubkey, user) in liquidatable_users {
+                for (pubkey, user, status) in liquidatable_users {
                     let pyth_price_update = user
                         .perp_positions
                         .iter()
@@ -832,6 +866,7 @@ impl LiquidatorBot {
                         current_slot,
                         current_time_millis(),
                         pyth_price_update,
+                        status,
                     )) {
                         Ok(()) => {}
                         Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
@@ -894,10 +929,7 @@ impl LiquidatorBot {
                                 Err(_) => return false,
                             };
 
-                        match check_margin_status(&margin_info) {
-                            MarginStatus::Liquidatable | MarginStatus::HighRisk => true,
-                            MarginStatus::Safe => false,
-                        }
+                        check_margin_status(&margin_info).is_at_risk()
                     } else {
                         false
                     }
@@ -977,13 +1009,14 @@ impl LiquidatorBot {
                         }
                     };
 
-                    match check_margin_status(&margin_info) {
-                        MarginStatus::Liquidatable => {
-                            high_risk.insert(*pubkey);
-                            newly_high_risk += 1;
-                            log::debug!(target: TARGET, "found liquidatable user: {pubkey:?}, margin:{margin_info:?}");
+                    let status = check_margin_status(&margin_info);
 
-                            let pyth_price_update = user_meta
+                    if status.is_liquidatable() {
+                        high_risk.insert(*pubkey);
+                        newly_high_risk += 1;
+                        log::info!(target: TARGET, "found liquidatable user: {pubkey:?}, margin:{margin_info:?}");
+
+                        let pyth_price_update = user_meta
                                 .user
                                 .perp_positions
                                 .iter()
@@ -1005,31 +1038,29 @@ impl LiquidatorBot {
                                     })
                                 });
 
-                            match self.liq_tx.try_send((
-                                *pubkey,
-                                user_meta.user.clone(),
-                                current_slot,
-                                current_time_millis(),
-                                pyth_price_update,
-                            )) {
-                                Ok(()) => {}
-                                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                                    log::warn!(
-                                        target: TARGET,
-                                        "liquidation channel full, dropping liquidation for {:?}",
-                                        pubkey
-                                    );
-                                }
-                                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                                    log::error!(target: TARGET, "liquidation channel closed");
-                                }
+                        match self.liq_tx.try_send((
+                            *pubkey,
+                            user_meta.user.clone(),
+                            current_slot,
+                            current_time_millis(),
+                            pyth_price_update,
+                            status,
+                        )) {
+                            Ok(()) => {}
+                            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                                log::warn!(
+                                    target: TARGET,
+                                    "liquidation channel full, dropping liquidation for {:?}",
+                                    pubkey
+                                );
+                            }
+                            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                                log::error!(target: TARGET, "liquidation channel closed");
                             }
                         }
-                        MarginStatus::HighRisk => {
-                            high_risk.insert(*pubkey);
-                            newly_high_risk += 1;
-                        }
-                        MarginStatus::Safe => {}
+                    } else if status.is_at_risk() {
+                        high_risk.insert(*pubkey);
+                        newly_high_risk += 1;
                     }
                 }
 
@@ -1271,14 +1302,21 @@ fn try_liquidate_with_match(
 fn spawn_liquidation_worker(
     tx_sender: TxSender,
     strategy: Arc<dyn LiquidationStrategy + Send + Sync>,
-    mut liq_rx: tokio::sync::mpsc::Receiver<(Pubkey, User, u64, u64, Option<PythPriceUpdate>)>,
+    mut liq_rx: tokio::sync::mpsc::Receiver<(
+        Pubkey,
+        User,
+        u64,
+        u64,
+        Option<PythPriceUpdate>,
+        UserMarginStatus,
+    )>,
     cu_limit: u32,
     priority_fee_subscriber: Arc<PriorityFeeSubscriber>,
 ) {
     let mut rate_limit = HashMap::<Pubkey, u64>::new();
 
     tokio::spawn(async move {
-        while let Some((liquidatee, user_account, slot, ts, pyth_price_update)) =
+        while let Some((liquidatee, user_account, slot, ts, pyth_price_update, status)) =
             liq_rx.recv().await
         {
             // Drop entries older than 1 second to handle backpressure
@@ -1323,6 +1361,7 @@ fn spawn_liquidation_worker(
                         cu_limit,
                         slot,
                         pyth_price_update,
+                        status,
                     ),
                 )
                 .await;
@@ -1438,7 +1477,65 @@ impl LiquidateWithMatchStrategy {
         cu_limit: u32,
         slot: u64,
         pyth_price_update: Option<PythPriceUpdate>,
+        status: &UserMarginStatus,
     ) {
+        // Check isolated liquidations first
+        for (market_index, iso_status) in &status.isolated {
+            if *iso_status == MarginStatus::Liquidatable {
+                if let Some(pos) = user_account.perp_positions.iter().find(|p| {
+                    p.market_index == *market_index && p.isolated_position_scaled_balance != 0
+                }) {
+                    metrics
+                        .liquidation_attempts
+                        .with_label_values(&["perp"])
+                        .inc();
+
+                    log::info!(
+                        target: TARGET,
+                        "try liquidate [ISOLATED]: https://app.drift.trade/?userAccount={liquidatee:?}, market={}",
+                        market_index
+                    );
+
+                    let Some(makers) = Self::find_top_makers(
+                        drift,
+                        dlob,
+                        market_state,
+                        *market_index,
+                        pos.base_asset_amount,
+                    ) else {
+                        return;
+                    };
+
+                    let oracle_price = market_state
+                        .get_perp_oracle_price(*market_index)
+                        .map(|x| x.price)
+                        .unwrap_or(0) as u64;
+
+                    let pyth_update =
+                        pyth_price_update.filter(|update| update.price != oracle_price);
+
+                    try_liquidate_with_match(
+                        drift,
+                        *market_index,
+                        keeper_subaccount,
+                        liquidatee,
+                        makers.as_slice(),
+                        tx_sender,
+                        priority_fee,
+                        cu_limit,
+                        slot,
+                        pyth_update,
+                    );
+                    return;
+                }
+            }
+        }
+
+        // Cross margin
+        if status.cross != MarginStatus::Liquidatable {
+            return;
+        }
+
         let Some(pos) = user_account
             .perp_positions
             .iter()
@@ -1720,6 +1817,7 @@ impl LiquidationStrategy for LiquidateWithMatchStrategy {
         cu_limit: u32,
         slot: u64,
         pyth_price_update: Option<PythPriceUpdate>,
+        status: UserMarginStatus,
     ) -> futures_util::future::BoxFuture<'a, ()> {
         Self::liquidate_perp(
             &self.drift,
@@ -1734,6 +1832,7 @@ impl LiquidationStrategy for LiquidateWithMatchStrategy {
             cu_limit,
             slot,
             pyth_price_update,
+            &status,
         );
 
         if self.use_spot_liquidation {

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -1865,7 +1865,7 @@ pub struct PrimaryLiquidationStrategy {
 }
 
 impl PrimaryLiquidationStrategy {
-    /// Liquidation policy: Prefer takeover for large positions (≥$10k), use makers for small positions,
+    /// Liquidation policy: Prefer takeover for small positions (<=$5k), use makers for large positions,
     /// fallback to takeover when no makers available. Skip if no makers and insufficient collateral.
     fn decide_perp_method(
         quote_asset_amount: u64,

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -265,7 +265,7 @@ async fn update_dashboard_state(
                 crate::http::MarketType::Spot
             },
             market_index: market_id.index(),
-            price: oracle_meta.price_data.price as i64,
+            price: oracle_meta.price_data.price,
             last_updated_slot: oracle_meta.last_updated_slot,
             last_updated_ms: oracle_meta.last_updated_timestamp_ms,
             age_slots,
@@ -667,14 +667,17 @@ impl LiquidatorBot {
                                 validate_data_freshness(user_meta, &oracle_prices, current_slot)
                             {
                                 match staleness_err {
-                                    StalenessError::UserAccountStale { age_slots } => {
+                                    StalenessError::UserAccountStale { age_slots: _ } => {
                                         // log::debug!(
                                         //     target: TARGET,
                                         //     "Recalculating margin for stale user {:?}: user account {} slots old",
                                         //     pubkey, age_slots
                                         // );
                                     }
-                                    StalenessError::OraclePriceStale { market, age_slots } => {
+                                    StalenessError::OraclePriceStale {
+                                        market: _,
+                                        age_slots: _,
+                                    } => {
                                         // log::debug!(
                                         //     target: TARGET,
                                         //     "Recalculating margin for {:?} with stale oracle: {:?} is {} slots old",
@@ -765,7 +768,7 @@ impl LiquidatorBot {
             // Only recheck margin for high-risk users on oracle price updates
             // Process in batches to avoid blocking the main event loop
             if oracle_update {
-                let high_risk_count = high_risk.len();
+                let _high_risk_count = high_risk.len();
                 let t0 = current_time_millis();
                 let mut liquidatable_users = Vec::new();
 
@@ -789,14 +792,17 @@ impl LiquidatorBot {
                             validate_data_freshness(user_meta, &oracle_prices, current_slot)
                         {
                             match staleness_err {
-                                StalenessError::UserAccountStale { age_slots } => {
+                                StalenessError::UserAccountStale { age_slots: _ } => {
                                     // log::debug!(
                                     //     target: TARGET,
                                     //     "Recalculating margin for stale user {:?}: user account {} slots old",
                                     //     pubkey, age_slots
                                     // );
                                 }
-                                StalenessError::OraclePriceStale { market, age_slots } => {
+                                StalenessError::OraclePriceStale {
+                                    market: _,
+                                    age_slots: _,
+                                } => {
                                     // log::debug!(
                                     //     target: TARGET,
                                     //     "Recalculating margin for {:?} with stale oracle: {:?} is {} slots old",
@@ -892,14 +898,17 @@ impl LiquidatorBot {
                             validate_data_freshness(user_meta, &oracle_prices, current_slot)
                         {
                             match staleness_err {
-                                StalenessError::UserAccountStale { age_slots } => {
+                                StalenessError::UserAccountStale { age_slots: _ } => {
                                     // log::debug!(
                                     //     target: TARGET,
                                     //     "Checking stale user {:?} for high-risk status: {} slots old",
                                     //     pubkey, age_slots
                                     // );
                                 }
-                                StalenessError::OraclePriceStale { market, age_slots } => {
+                                StalenessError::OraclePriceStale {
+                                    market: _,
+                                    age_slots: _,
+                                } => {
                                     // log::debug!(
                                     //     target: TARGET,
                                     //     "Checking {:?} with stale oracle {:?}: {} slots old",
@@ -963,14 +972,17 @@ impl LiquidatorBot {
                         validate_data_freshness(user_meta, &oracle_prices, current_slot)
                     {
                         match staleness_err {
-                            StalenessError::UserAccountStale { age_slots } => {
+                            StalenessError::UserAccountStale { age_slots: _ } => {
                                 // log::debug!(
                                 //     target: TARGET,
                                 //     "Recalculating margin for stale user {:?}: user account {} slots old",
                                 //     pubkey, age_slots
                                 // );
                             }
-                            StalenessError::OraclePriceStale { market, age_slots } => {
+                            StalenessError::OraclePriceStale {
+                                market: _,
+                                age_slots: _,
+                            } => {
                                 // log::debug!(
                                 //     target: TARGET,
                                 //     "Recalculating margin for {:?} with stale oracle: {:?} is {} slots old",
@@ -1135,7 +1147,7 @@ async fn setup_grpc(
                     {
                         let tx = tx.clone();
                         move |acc| {
-                            let user: &User = drift_rs::utils::deser_zero_copy(&acc.data);
+                            let user: &User = drift_rs::utils::deser_zero_copy(acc.data);
                             if let Err(err) = tx.try_send(GrpcEvent::UserUpdate {
                                 pubkey: acc.pubkey,
                                 user: user.clone(),
@@ -1670,11 +1682,9 @@ impl LiquidateWithMatchStrategy {
                 .expect("liability spot market");
 
             let in_token_account =
-                drift_rs::Wallet::derive_associated_token_address(&authority, &asset_spot_market);
-            let out_token_account = drift_rs::Wallet::derive_associated_token_address(
-                &authority,
-                &liability_spot_market,
-            );
+                drift_rs::Wallet::derive_associated_token_address(authority, asset_spot_market);
+            let out_token_account =
+                drift_rs::Wallet::derive_associated_token_address(authority, liability_spot_market);
 
             let t0 = std::time::Instant::now();
             let (jupiter_result, titan_result) = tokio::join!(
@@ -1749,8 +1759,8 @@ impl LiquidateWithMatchStrategy {
                 .with_priority_fee(priority_fee, Some(cu_limit))
                 .titan_swap_liquidate(
                     titan_result.unwrap(),
-                    &asset_spot_market,
-                    &liability_spot_market,
+                    asset_spot_market,
+                    liability_spot_market,
                     &in_token_account,
                     &out_token_account,
                     asset_market_index,
@@ -1768,8 +1778,8 @@ impl LiquidateWithMatchStrategy {
                 .with_priority_fee(priority_fee, Some(cu_limit))
                 .jupiter_swap_liquidate(
                     jupiter_result.unwrap(),
-                    &asset_spot_market,
-                    &liability_spot_market,
+                    asset_spot_market,
+                    liability_spot_market,
                     &in_token_account,
                     &out_token_account,
                     asset_market_index,

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -261,7 +261,7 @@ async fn update_dashboard_state(
                 crate::http::MarketType::Spot
             },
             market_index: market_id.index(),
-            price: oracle_meta.price_data.price as i64,
+            price: oracle_meta.price_data.price,
             last_updated_slot: oracle_meta.last_updated_slot,
             last_updated_ms: oracle_meta.last_updated_timestamp_ms,
             age_slots,
@@ -628,14 +628,17 @@ impl LiquidatorBot {
                                 validate_data_freshness(user_meta, &oracle_prices, current_slot)
                             {
                                 match staleness_err {
-                                    StalenessError::UserAccountStale { age_slots } => {
+                                    StalenessError::UserAccountStale { age_slots: _ } => {
                                         // log::debug!(
                                         //     target: TARGET,
                                         //     "Recalculating margin for stale user {:?}: user account {} slots old",
                                         //     pubkey, age_slots
                                         // );
                                     }
-                                    StalenessError::OraclePriceStale { market, age_slots } => {
+                                    StalenessError::OraclePriceStale {
+                                        market: _,
+                                        age_slots: _,
+                                    } => {
                                         // log::debug!(
                                         //     target: TARGET,
                                         //     "Recalculating margin for {:?} with stale oracle: {:?} is {} slots old",
@@ -729,7 +732,7 @@ impl LiquidatorBot {
             // Only recheck margin for high-risk users on oracle price updates
             // Process in batches to avoid blocking the main event loop
             if oracle_update {
-                let high_risk_count = high_risk.len();
+                let _high_risk_count = high_risk.len();
                 let t0 = current_time_millis();
                 let mut liquidatable_users = Vec::new();
 
@@ -753,14 +756,17 @@ impl LiquidatorBot {
                             validate_data_freshness(user_meta, &oracle_prices, current_slot)
                         {
                             match staleness_err {
-                                StalenessError::UserAccountStale { age_slots } => {
+                                StalenessError::UserAccountStale { age_slots: _ } => {
                                     // log::debug!(
                                     //     target: TARGET,
                                     //     "Recalculating margin for stale user {:?}: user account {} slots old",
                                     //     pubkey, age_slots
                                     // );
                                 }
-                                StalenessError::OraclePriceStale { market, age_slots } => {
+                                StalenessError::OraclePriceStale {
+                                    market: _,
+                                    age_slots: _,
+                                } => {
                                     // log::debug!(
                                     //     target: TARGET,
                                     //     "Recalculating margin for {:?} with stale oracle: {:?} is {} slots old",
@@ -857,14 +863,17 @@ impl LiquidatorBot {
                             validate_data_freshness(user_meta, &oracle_prices, current_slot)
                         {
                             match staleness_err {
-                                StalenessError::UserAccountStale { age_slots } => {
+                                StalenessError::UserAccountStale { age_slots: _ } => {
                                     // log::debug!(
                                     //     target: TARGET,
                                     //     "Checking stale user {:?} for high-risk status: {} slots old",
                                     //     pubkey, age_slots
                                     // );
                                 }
-                                StalenessError::OraclePriceStale { market, age_slots } => {
+                                StalenessError::OraclePriceStale {
+                                    market: _,
+                                    age_slots: _,
+                                } => {
                                     // log::debug!(
                                     //     target: TARGET,
                                     //     "Checking {:?} with stale oracle {:?}: {} slots old",
@@ -931,14 +940,17 @@ impl LiquidatorBot {
                         validate_data_freshness(user_meta, &oracle_prices, current_slot)
                     {
                         match staleness_err {
-                            StalenessError::UserAccountStale { age_slots } => {
+                            StalenessError::UserAccountStale { age_slots: _ } => {
                                 // log::debug!(
                                 //     target: TARGET,
                                 //     "Recalculating margin for stale user {:?}: user account {} slots old",
                                 //     pubkey, age_slots
                                 // );
                             }
-                            StalenessError::OraclePriceStale { market, age_slots } => {
+                            StalenessError::OraclePriceStale {
+                                market: _,
+                                age_slots: _,
+                            } => {
                                 // log::debug!(
                                 //     target: TARGET,
                                 //     "Recalculating margin for {:?} with stale oracle: {:?} is {} slots old",
@@ -1104,7 +1116,7 @@ async fn setup_grpc(
                     {
                         let tx = tx.clone();
                         move |acc| {
-                            let user: &User = drift_rs::utils::deser_zero_copy(&acc.data);
+                            let user: &User = drift_rs::utils::deser_zero_copy(acc.data);
                             if let Err(err) = tx.try_send(GrpcEvent::UserUpdate {
                                 pubkey: acc.pubkey,
                                 user: user.clone(),
@@ -1573,11 +1585,9 @@ impl LiquidateWithMatchStrategy {
                 .expect("liability spot market");
 
             let in_token_account =
-                drift_rs::Wallet::derive_associated_token_address(&authority, &asset_spot_market);
-            let out_token_account = drift_rs::Wallet::derive_associated_token_address(
-                &authority,
-                &liability_spot_market,
-            );
+                drift_rs::Wallet::derive_associated_token_address(authority, asset_spot_market);
+            let out_token_account =
+                drift_rs::Wallet::derive_associated_token_address(authority, liability_spot_market);
 
             let t0 = std::time::Instant::now();
             let (jupiter_result, titan_result) = tokio::join!(
@@ -1652,8 +1662,8 @@ impl LiquidateWithMatchStrategy {
                 .with_priority_fee(priority_fee, Some(cu_limit))
                 .titan_swap_liquidate(
                     titan_result.unwrap(),
-                    &asset_spot_market,
-                    &liability_spot_market,
+                    asset_spot_market,
+                    liability_spot_market,
                     &in_token_account,
                     &out_token_account,
                     asset_market_index,
@@ -1671,8 +1681,8 @@ impl LiquidateWithMatchStrategy {
                 .with_priority_fee(priority_fee, Some(cu_limit))
                 .jupiter_swap_liquidate(
                     jupiter_result.unwrap(),
-                    &asset_spot_market,
-                    &liability_spot_market,
+                    asset_spot_market,
+                    liability_spot_market,
                     &in_token_account,
                     &out_token_account,
                     asset_market_index,

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -7,6 +7,7 @@
 //! The default strategy tries to liquidate perp positions against resting orders
 //!
 use anchor_lang::Discriminator;
+use dashmap::DashMap;
 use futures_util::FutureExt;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
@@ -359,7 +360,7 @@ pub trait LiquidationStrategy {
         cu_limit: u32,
         slot: u64,
         pyth_price_update: Option<PythPriceUpdate>,
-        collateral_info_per_subaccount: Arc<RwLock<HashMap<Pubkey, CollateralInfo>>>,
+        collateral_info_per_subaccount: Arc<DashMap<Pubkey, CollateralInfo>>,
         status: UserMarginStatus,
     ) -> futures_util::future::BoxFuture<'a, ()>;
 }
@@ -406,7 +407,7 @@ pub struct LiquidatorBot {
     /// Dashboard state for HTTP API
     dashboard_state: DashboardStateRef,
     /// Track collateral info per subaccount
-    collateral_info_per_subaccount: Arc<RwLock<HashMap<Pubkey, CollateralInfo>>>,
+    collateral_info_per_subaccount: Arc<DashMap<Pubkey, CollateralInfo>>,
 }
 
 impl LiquidatorBot {
@@ -523,9 +524,8 @@ impl LiquidatorBot {
 
         log::info!(target: TARGET, "subscribed pyth price feeds");
 
-        let collateral_info_per_subaccount = Arc::new(RwLock::new(
-            get_collateral_info_per_subaccount(&drift, &config.get_subaccounts()).await,
-        ));
+        let collateral_info_per_subaccount =
+            Arc::new(get_collateral_info_per_subaccount(&drift, &config.get_subaccounts()).await);
 
         let cu_limit = std::env::var("FILL_CU_LIMIT")
             .ok()
@@ -723,7 +723,13 @@ impl LiquidatorBot {
                         let new_collateral =
                             get_collateral_info_per_subaccount(&drift, &config.get_subaccounts())
                                 .await;
-                        *self.collateral_info_per_subaccount.write().unwrap() = new_collateral;
+
+                        self.collateral_info_per_subaccount.clear();
+
+                        for (subaccount, collateral_info) in new_collateral {
+                            self.collateral_info_per_subaccount
+                                .insert(subaccount, collateral_info);
+                        }
 
                         let old_user = users.get(&pubkey).map(|m| &m.user);
                         dlob_notifier.user_update(pubkey, old_user, &user, update_slot);
@@ -1214,20 +1220,30 @@ fn derisk_subaccount(
                 base_asset_amount: position.base_asset_amount.unsigned_abs(),
                 market_index: position.market_index,
                 reduce_only: true,
+                max_ts: Some((current_time_millis() / 1000 + 5) as i64), // ~5s
                 ..Default::default()
             }]);
+
+            tx_sender.send_tx(
+                tx_builder.build(),
+                TxIntent::Derisk {
+                    market_index: position.market_index,
+                    subaccount,
+                },
+                cu_limit as u64,
+            );
         } else {
             tx_builder = tx_builder.settle_pnl(position.market_index, None, None);
-        }
 
-        tx_sender.send_tx(
-            tx_builder.build(),
-            TxIntent::Derisk {
-                market_index: position.market_index,
-                subaccount,
-            },
-            cu_limit as u64,
-        );
+            tx_sender.send_tx(
+                tx_builder.build(),
+                TxIntent::SettlePnl {
+                    market_index: position.market_index,
+                    subaccount,
+                },
+                cu_limit as u64,
+            );
+        }
     }
 
     // TODO: Add spot derisking, swap any position back to USDC using jupiter/titan
@@ -1255,8 +1271,8 @@ fn spawn_derisk_loop(
 async fn get_collateral_info_per_subaccount(
     drift: &DriftClient,
     subaccounts: &[u16],
-) -> HashMap<Pubkey, CollateralInfo> {
-    let mut collateral_info_per_subaccount = HashMap::<Pubkey, CollateralInfo>::new();
+) -> DashMap<Pubkey, CollateralInfo> {
+    let collateral_info_per_subaccount = DashMap::<Pubkey, CollateralInfo>::new();
     for subaccount in subaccounts {
         let subaccount_pubkey = Wallet::derive_user_account(&drift.wallet.authority(), *subaccount);
         match drift.get_user_account(&subaccount_pubkey).await {
@@ -1728,7 +1744,7 @@ fn spawn_liquidation_worker(
     )>,
     cu_limit: u32,
     priority_fee_subscriber: Arc<PriorityFeeSubscriber>,
-    collateral_info_per_subaccount: Arc<RwLock<HashMap<Pubkey, CollateralInfo>>>,
+    collateral_info_per_subaccount: Arc<DashMap<Pubkey, CollateralInfo>>,
 ) {
     let mut rate_limit = HashMap::<Pubkey, u64>::new();
 
@@ -1852,15 +1868,14 @@ impl PrimaryLiquidationStrategy {
     /// Liquidation policy: Prefer takeover for large positions (≥$10k), use makers for small positions,
     /// fallback to takeover when no makers available. Skip if no makers and insufficient collateral.
     fn decide_perp_method(
-        base_asset_amount: u64,
-        oracle_price: u64,
+        quote_asset_amount: u64,
         collateral_available: i128,
         collateral_required: u128,
         has_makers: bool,
     ) -> LiquidationType {
         const POSITION_AMOUNT_THRESHOLD: u64 = 1_000 * BASE_PRECISION_U64;
 
-        let is_small_position = base_asset_amount * oracle_price <= POSITION_AMOUNT_THRESHOLD;
+        let is_small_position = quote_asset_amount <= POSITION_AMOUNT_THRESHOLD;
         let can_afford_takeover = collateral_available >= collateral_required as i128;
 
         if is_small_position && can_afford_takeover {
@@ -1916,12 +1931,11 @@ impl PrimaryLiquidationStrategy {
         Some(collateral)
     }
 
-    fn calculate_net_collateral_requirement(
-        liability_size: u128,
+    fn extract_collateral_params(
+        market_state: Arc<RwLock<MarketState>>,
         liability: &PositionInfo,
         asset: &PositionInfo,
-        market_state: Arc<RwLock<MarketState>>,
-    ) -> i128 {
+    ) -> (i64, u128, u128, u128, i64, u128, u128, u128) {
         let state = market_state.read().unwrap().load();
 
         let (liability_oracle, liability_precision) = if liability.market_type == MarketType::Spot {
@@ -1933,10 +1947,20 @@ impl PrimaryLiquidationStrategy {
                 .spot_markets
                 .get(&liability.market_index)
                 .expect("liability market");
-            (oracle, 10_u128.pow(market.decimals))
+            (oracle.price, 10_u128.pow(market.decimals))
         } else {
             let oracle = state.spot_oracle_prices.get(&0).expect("USDC oracle");
-            (oracle, QUOTE_PRECISION)
+            (oracle.price, QUOTE_PRECISION)
+        };
+
+        let liability_weight = if liability.market_type == MarketType::Spot {
+            let market = state
+                .spot_markets
+                .get(&liability.market_index)
+                .expect("liability spot market");
+            market.initial_liability_weight as u128
+        } else {
+            1u128
         };
 
         let (asset_oracle, asset_precision) = if asset.market_type == MarketType::Spot {
@@ -1948,33 +1972,58 @@ impl PrimaryLiquidationStrategy {
                 .spot_markets
                 .get(&asset.market_index)
                 .expect("asset market");
-            (oracle, 10_u128.pow(market.decimals))
+            (oracle.price, 10_u128.pow(market.decimals))
         } else {
             let oracle = state.spot_oracle_prices.get(&0).expect("USDC oracle");
-            (oracle, QUOTE_PRECISION)
+            (oracle.price, QUOTE_PRECISION)
         };
 
-        let asset_amount_back_in_tokens = liability_size
-            .saturating_mul(liability_oracle.price as u128)
-            .saturating_div(asset_oracle.price as u128)
-            .saturating_mul(asset_precision)
-            .saturating_div(liability_precision);
-
         let (asset_weight, asset_weight_precision) = if asset.market_type == MarketType::Spot {
-            let spot_market = state
+            let market = state
                 .spot_markets
                 .get(&asset.market_index)
                 .expect("asset spot market");
             (
-                spot_market.initial_asset_weight as u128,
+                market.initial_asset_weight as u128,
                 SPOT_WEIGHT_PRECISION_U128,
             )
         } else {
             (SPOT_WEIGHT_PRECISION_U128, SPOT_WEIGHT_PRECISION_U128)
         };
 
+        (
+            liability_oracle,
+            liability_precision,
+            liability_weight,
+            SPOT_WEIGHT_PRECISION_U128,
+            asset_oracle,
+            asset_precision,
+            asset_weight,
+            asset_weight_precision,
+        )
+    }
+
+    fn calculate_net_collateral_requirement_with_params(
+        liability_size: u128,
+        liability: &PositionInfo,
+        asset: &PositionInfo,
+        liability_oracle_price: i64,
+        liability_precision: u128,
+        liability_weight: u128,
+        liability_weight_precision: u128,
+        asset_oracle_price: i64,
+        asset_precision: u128,
+        asset_weight: u128,
+        asset_weight_precision: u128,
+    ) -> i128 {
+        let asset_amount_back_in_tokens = liability_size
+            .saturating_mul(liability_oracle_price as u128)
+            .saturating_div(asset_oracle_price as u128)
+            .saturating_mul(asset_precision)
+            .saturating_div(liability_precision);
+
         let asset_amount_back_in_collateral = asset_amount_back_in_tokens
-            .saturating_mul(asset_oracle.price as u128)
+            .saturating_mul(asset_oracle_price as u128)
             .saturating_mul(QUOTE_PRECISION)
             .saturating_mul(asset_weight)
             .saturating_div(asset_weight_precision)
@@ -1982,17 +2031,13 @@ impl PrimaryLiquidationStrategy {
             .saturating_div(PRICE_PRECISION);
 
         let liability_collateral_impact = if liability.market_type == MarketType::Spot {
-            let spot_market = state
-                .spot_markets
-                .get(&liability.market_index)
-                .expect("liability spot market");
             liability_size
-                .saturating_mul(liability_oracle.price as u128)
+                .saturating_mul(liability_oracle_price as u128)
                 .saturating_div(PRICE_PRECISION)
                 .saturating_mul(QUOTE_PRECISION)
                 .saturating_div(liability_precision)
-                .saturating_mul(spot_market.initial_liability_weight as u128)
-                .saturating_div(SPOT_WEIGHT_PRECISION_U128)
+                .saturating_mul(liability_weight)
+                .saturating_div(liability_weight_precision)
         } else {
             liability
                 .collateral_required
@@ -2005,6 +2050,30 @@ impl PrimaryLiquidationStrategy {
         );
 
         net_impact as i128
+    }
+
+    fn calculate_net_collateral_requirement(
+        liability_size: u128,
+        liability: &PositionInfo,
+        asset: &PositionInfo,
+        market_state: Arc<RwLock<MarketState>>,
+    ) -> i128 {
+        let (l_oracle, l_prec, l_weight, l_weight_prec, a_oracle, a_prec, a_weight, a_weight_prec) =
+            Self::extract_collateral_params(market_state, liability, asset);
+
+        Self::calculate_net_collateral_requirement_with_params(
+            liability_size,
+            liability,
+            asset,
+            l_oracle,
+            l_prec,
+            l_weight,
+            l_weight_prec,
+            a_oracle,
+            a_prec,
+            a_weight,
+            a_weight_prec,
+        )
     }
 
     /// finds the max liquidation amount whose collateral impact fits within available collateral,
@@ -2151,18 +2220,19 @@ impl PrimaryLiquidationStrategy {
     }
 
     // Port of  https://github.com/drift-labs/protocol-v2/blob/master/sdk/src/user.ts#L3941-L3971
-    fn get_safest_tiers(user_account: &User, market_state: Arc<RwLock<MarketState>>) -> (u8, u8) {
+    fn get_safest_tiers(user_account: &User, drift: &DriftClient) -> (u8, u8) {
         let mut safest_perp_tier = 4;
         let mut safest_spot_tier = 4;
-
-        let state = market_state.read().unwrap().load();
 
         for perp_position in user_account
             .perp_positions
             .iter()
             .filter(|p| !p.is_available())
         {
-            if let Some(perp_market) = state.perp_markets.get(&perp_position.market_index) {
+            if let Some(perp_market) = drift
+                .program_data()
+                .perp_market_config_by_index(perp_position.market_index)
+            {
                 safest_perp_tier = safest_perp_tier.min(perp_market.contract_tier.to_number());
             }
         }
@@ -2172,7 +2242,10 @@ impl PrimaryLiquidationStrategy {
             .iter()
             .filter(|p| !p.is_available() && p.balance_type != SpotBalanceType::Deposit)
         {
-            if let Some(spot_market) = state.spot_markets.get(&spot_position.market_index) {
+            if let Some(spot_market) = drift
+                .program_data()
+                .spot_market_config_by_index(spot_position.market_index)
+            {
                 safest_spot_tier = safest_spot_tier.min(spot_market.asset_tier.to_number());
             }
         }
@@ -2190,19 +2263,11 @@ impl PrimaryLiquidationStrategy {
     ) -> Option<(PositionInfo, Option<PositionInfo>)> {
         let state = market_state.read().unwrap().load();
 
-        let mut liabilities: Vec<PositionInfo> = perp_positions
+        let (mut liabilities, mut assets): (Vec<PositionInfo>, Vec<PositionInfo>) = perp_positions
             .iter()
             .chain(spot_positions)
-            .filter(|p| !p.is_asset)
             .cloned()
-            .collect();
-
-        let mut assets: Vec<PositionInfo> = perp_positions
-            .iter()
-            .chain(spot_positions)
-            .filter(|p| p.is_asset)
-            .cloned()
-            .collect();
+            .partition(|p| !p.is_asset);
 
         liabilities.sort_by(|a, b| {
             b.collateral_required
@@ -2242,7 +2307,7 @@ impl PrimaryLiquidationStrategy {
         subaccounts: &[Pubkey],
         needs_perp_room: bool,
         needs_spot_room: bool,
-        collateral_info_per_subaccount: &HashMap<Pubkey, CollateralInfo>,
+        collateral_info_per_subaccount: &DashMap<Pubkey, CollateralInfo>,
         min_collateral_required: u128,
     ) -> Option<Pubkey> {
         let mut candidates: Vec<(Pubkey, i128)> = subaccounts
@@ -2360,7 +2425,7 @@ impl PrimaryLiquidationStrategy {
         cu_limit: u32,
         slot: u64,
         pyth_price_update: Option<PythPriceUpdate>,
-        collateral_info_per_subaccount: Arc<RwLock<HashMap<Pubkey, CollateralInfo>>>,
+        collateral_info_per_subaccount: Arc<DashMap<Pubkey, CollateralInfo>>,
         status: &UserMarginStatus,
     ) {
         let Some(subaccount) = subaccounts.first() else {
@@ -2451,7 +2516,7 @@ impl PrimaryLiquidationStrategy {
         };
 
         // Check available collateral
-        let collateral_map = collateral_info_per_subaccount.read().unwrap();
+        let collateral_map = collateral_info_per_subaccount;
         let Some(collateral_info) = collateral_map.get(&subaccount) else {
             log::warn!(target: TARGET, "no collateral info for keeper subaccount");
             return;
@@ -2481,8 +2546,7 @@ impl PrimaryLiquidationStrategy {
         let pyth_update = pyth_price_update.filter(|update| update.price != oracle_price);
 
         let method = Self::decide_perp_method(
-            pos.base_asset_amount.try_into().unwrap(),
-            oracle_price,
+            pos.quote_asset_amount.try_into().unwrap(),
             collateral_info.free,
             collateral_required,
             makers.is_some(),
@@ -2800,23 +2864,23 @@ impl PrimaryLiquidationStrategy {
         cu_limit: u32,
         slot: u64,
         pyth_price_update: Option<PythPriceUpdate>,
-        collateral_info_per_subaccount: Arc<RwLock<HashMap<Pubkey, CollateralInfo>>>,
+        collateral_info_per_subaccount: Arc<DashMap<Pubkey, CollateralInfo>>,
     ) {
-        let full_net_req = Self::calculate_net_collateral_requirement(
+        let net_collateral_req = Self::calculate_net_collateral_requirement(
             liability.collateral_required.unsigned_abs(),
             &liability,
             &asset,
             Arc::clone(&market_state),
         );
 
-        let collateral_map = collateral_info_per_subaccount.read().unwrap();
+        let collateral_map = collateral_info_per_subaccount;
         let Some(subaccount) = Self::find_best_subaccount_for_liquidation(
             drift,
             subaccounts,
             false,
             true,
             &collateral_map,
-            full_net_req.max(0) as u128,
+            net_collateral_req.max(0) as u128,
         ) else {
             return;
         };
@@ -2828,7 +2892,9 @@ impl PrimaryLiquidationStrategy {
         let available = collateral_info.free;
         let tolerance = available / 10;
 
-        let liq_amount = if full_net_req <= available {
+        let params = Self::extract_collateral_params(Arc::clone(&market_state), &liability, &asset);
+
+        let liq_amount = if net_collateral_req <= available {
             liability.collateral_required.unsigned_abs()
         } else {
             Self::find_max_liq_amount(
@@ -2836,11 +2902,9 @@ impl PrimaryLiquidationStrategy {
                 available,
                 tolerance,
                 |size| {
-                    Self::calculate_net_collateral_requirement(
-                        size,
-                        &liability,
-                        &asset,
-                        Arc::clone(&market_state),
+                    Self::calculate_net_collateral_requirement_with_params(
+                        size, &liability, &asset, params.0, params.1, params.2, params.3, params.4,
+                        params.5, params.6, params.7,
                     )
                 },
             )
@@ -2878,7 +2942,7 @@ impl PrimaryLiquidationStrategy {
         cu_limit: u32,
         slot: u64,
         pyth_price_update: Option<PythPriceUpdate>,
-        collateral_info_per_subaccount: Arc<RwLock<HashMap<Pubkey, CollateralInfo>>>,
+        collateral_info_per_subaccount: Arc<DashMap<Pubkey, CollateralInfo>>,
     ) {
         let net_collateral_req = Self::calculate_net_collateral_requirement(
             liability.base_amount.unsigned_abs() as u128,
@@ -2887,7 +2951,7 @@ impl PrimaryLiquidationStrategy {
             Arc::clone(&market_state),
         );
 
-        let collateral_map = collateral_info_per_subaccount.read().unwrap();
+        let collateral_map = collateral_info_per_subaccount;
         let Some(subaccount) = Self::find_best_subaccount_for_liquidation(
             drift,
             subaccounts,
@@ -2903,21 +2967,25 @@ impl PrimaryLiquidationStrategy {
         let available = collateral_info.free;
         let tolerance = available / 10;
 
-        let max_liq_amount = Self::find_max_liq_amount(
-            liability.base_amount.unsigned_abs() as u128,
-            available,
-            tolerance,
-            |size| {
-                Self::calculate_net_collateral_requirement(
-                    size,
-                    &liability,
-                    &asset,
-                    Arc::clone(&market_state),
-                )
-            },
-        );
+        let params = Self::extract_collateral_params(Arc::clone(&market_state), &liability, &asset);
 
-        if max_liq_amount == 0 {
+        let liq_amount = if net_collateral_req <= available {
+            liability.collateral_required.unsigned_abs()
+        } else {
+            Self::find_max_liq_amount(
+                liability.collateral_required.unsigned_abs(),
+                available,
+                tolerance,
+                |size| {
+                    Self::calculate_net_collateral_requirement_with_params(
+                        size, &liability, &asset, params.0, params.1, params.2, params.3, params.4,
+                        params.5, params.6, params.7,
+                    )
+                },
+            )
+        };
+
+        if liq_amount == 0 {
             return;
         }
 
@@ -2927,7 +2995,7 @@ impl PrimaryLiquidationStrategy {
             liquidatee,
             &liability,
             &asset,
-            max_liq_amount,
+            liq_amount,
             tx_sender,
             priority_fee,
             cu_limit,
@@ -2947,7 +3015,7 @@ impl LiquidationStrategy for PrimaryLiquidationStrategy {
         cu_limit: u32,
         slot: u64,
         pyth_price_update: Option<PythPriceUpdate>,
-        collateral_info_per_subaccount: Arc<RwLock<HashMap<Pubkey, CollateralInfo>>>,
+        collateral_info_per_subaccount: Arc<DashMap<Pubkey, CollateralInfo>>,
         status: UserMarginStatus,
     ) -> futures_util::future::BoxFuture<'a, ()> {
         let perp_positions = Self::get_perp_positions_info(
@@ -2961,7 +3029,7 @@ impl LiquidationStrategy for PrimaryLiquidationStrategy {
         );
 
         let (safest_perp_tier, safest_spot_tier) =
-            Self::get_safest_tiers(&user_account, Arc::clone(&self.market_state));
+            Self::get_safest_tiers(&user_account, &self.drift);
 
         let Some((liability, asset)) = Self::pick_best_asset_liability_combo(
             Arc::clone(&self.market_state),

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -674,6 +674,9 @@ impl LiquidatorBot {
         let mut exclude_count = 0;
         let mut initial_high_risk_count = 0;
 
+        let mut last_collateral_refresh_ms: u64 = 0;
+        const COLLATERAL_REFRESH_INTERVAL_MS: u64 = 5_000;
+
         log::info!(target: TARGET, "starting user account initialization");
 
         drift
@@ -789,33 +792,42 @@ impl LiquidatorBot {
                         user,
                         slot: update_slot,
                     } => {
-                        // Update collaterals
-                        let new_collateral =
-                            get_collateral_info_per_subaccount(&drift, &self.subaccount_pubkeys)
-                                .await;
+                        let now_ms = current_time_millis();
+                        if now_ms.saturating_sub(last_collateral_refresh_ms)
+                            >= COLLATERAL_REFRESH_INTERVAL_MS
+                        {
+                            last_collateral_refresh_ms = now_ms;
 
-                        self.collateral_info_per_subaccount.clear();
+                            // Update collaterals
+                            let new_collateral = get_collateral_info_per_subaccount(
+                                &drift,
+                                &self.subaccount_pubkeys,
+                            )
+                            .await;
 
-                        for (subaccount_pubkey, collateral_info) in new_collateral {
-                            self.collateral_info_per_subaccount
-                                .insert(subaccount_pubkey, collateral_info);
-                        }
+                            self.collateral_info_per_subaccount.clear();
 
-                        // Update free collateral accounting for in flight txs
-                        for entry in self.collateral_info_per_subaccount.iter() {
-                            let subaccount_pubkey = entry.key();
-                            let collateral_info = entry.value();
-                            let mut free = collateral_info.free;
+                            for (subaccount_pubkey, collateral_info) in new_collateral {
+                                self.collateral_info_per_subaccount
+                                    .insert(subaccount_pubkey, collateral_info);
+                            }
 
-                            if let Some(in_flight) = self.txs_in_flight.get(subaccount_pubkey) {
-                                for sig in in_flight.value().iter() {
-                                    if let Some(reserved) = self.tx_sig_to_collateral.get(sig) {
-                                        free = free.saturating_sub(reserved.value().0 as i128);
+                            // Update free collateral accounting for in flight txs
+                            for entry in self.collateral_info_per_subaccount.iter() {
+                                let subaccount_pubkey = entry.key();
+                                let collateral_info = entry.value();
+                                let mut free = collateral_info.free;
+
+                                if let Some(in_flight) = self.txs_in_flight.get(subaccount_pubkey) {
+                                    for sig in in_flight.value().iter() {
+                                        if let Some(reserved) = self.tx_sig_to_collateral.get(sig) {
+                                            free = free.saturating_sub(reserved.value().0 as i128);
+                                        }
                                     }
                                 }
+                                self.free_collateral_per_subaccount
+                                    .insert(*subaccount_pubkey, free.max(0) as u128);
                             }
-                            self.free_collateral_per_subaccount
-                                .insert(*subaccount_pubkey, free.max(0) as u128);
                         }
 
                         let old_user = users.get(&pubkey).map(|m| &m.user);

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -7,33 +7,45 @@
 //! The default strategy tries to liquidate perp positions against resting orders
 //!
 use anchor_lang::Discriminator;
+use dashmap::DashMap;
 use futures_util::FutureExt;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     sync::{Arc, RwLock},
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use tokio::sync::mpsc::error::TryRecvError;
 
 use drift_rs::{
     dlob::{DLOBNotifier, DLOB},
-    ffi::{OraclePriceData, SimplifiedMarginCalculation},
+    ffi::{calculate_claimable_pnl, OraclePriceData, SimplifiedMarginCalculation},
     grpc::{
         grpc_subscriber::{AccountFilter, GrpcConnectionOpts},
         TransactionUpdate,
     },
     jupiter::SwapMode,
     market_state::MarketStateData,
+    math::{
+        constants::{
+            BASE_PRECISION, MARGIN_PRECISION_U128, PRICE_PRECISION, QUOTE_PRECISION,
+            SPOT_WEIGHT_PRECISION_U128,
+        },
+        liquidation::{calculate_collateral, CollateralInfo},
+        tiers::perp_tier_is_as_safe_as,
+    },
     priority_fee_subscriber::PriorityFeeSubscriber,
     titan,
     types::{
         accounts::{PerpMarket, SpotMarket, User},
-        MarginRequirementType, MarketId, MarketStatus, MarketType, OracleSource, SpotBalanceType,
+        MarginRequirementType, MarketId, MarketStatus, MarketType, OracleSource, OrderParams,
+        OrderType, PerpPosition, PositionDirection, SpotBalanceType, SpotPosition,
     },
     DriftClient, GrpcSubscribeOpts, MarketState, Pubkey, TransactionBuilder,
 };
 use drift_rs::{jupiter::JupiterSwapApi, titan::TitanSwapApi};
-use solana_sdk::{account::Account, clock::Slot, compute_budget::ComputeBudgetInstruction};
+use solana_sdk::{
+    account::Account, clock::Slot, compute_budget::ComputeBudgetInstruction, signature::Signature,
+};
 
 use crate::{
     filler::{TxSender, TxWorker},
@@ -403,6 +415,14 @@ pub struct LiquidatorBot {
     pyth_price_feed: Option<tokio::sync::mpsc::Receiver<PythPriceUpdate>>,
     /// Dashboard state for HTTP API
     dashboard_state: DashboardStateRef,
+    subaccount_pubkeys: Vec<Pubkey>,
+    /// Track collateral info per subaccount
+    collateral_info_per_subaccount: Arc<DashMap<Pubkey, CollateralInfo>>,
+    /// In flight txs tracking
+    txs_in_flight: Arc<DashMap<Pubkey, HashSet<Signature>>>,
+    // Map(Signature,(collateral, ts))
+    tx_sig_to_collateral: Arc<DashMap<Signature, (u128, u64)>>,
+    free_collateral_per_subaccount: Arc<DashMap<Pubkey, u128>>,
 }
 
 impl LiquidatorBot {
@@ -413,9 +433,6 @@ impl LiquidatorBot {
         dashboard_state: DashboardStateRef,
     ) -> Self {
         let dlob: &'static DLOB = Box::leak(Box::new(DLOB::default()));
-        let tx_worker = TxWorker::new(drift.clone(), Arc::clone(&metrics), config.dry);
-        let rt = tokio::runtime::Handle::current();
-        let tx_sender = tx_worker.run(rt);
 
         let mut perp_market_ids = match config.use_markets() {
             UseMarkets::All => drift.get_all_perp_market_ids(),
@@ -457,10 +474,51 @@ impl LiquidatorBot {
             PriorityFeeSubscriber::new(drift.rpc().url(), &market_pubkeys);
         let priority_fee_subscriber = priority_fee_subscriber.subscribe();
 
-        let keeper_subaccount = drift.wallet.sub_account(config.sub_account_id);
-        log::info!(target: TARGET, "liquidator 🫠 bot started: authority={:?}, subaccount={:?}", drift.wallet.authority(), keeper_subaccount);
+        let subaccounts: Vec<Pubkey> = config
+            .get_subaccounts()
+            .iter()
+            .map(|id| drift.wallet.sub_account(*id))
+            .collect();
+
+        log::info!(target: TARGET, "liquidator 🫠 bot started: authority={:?}, subaccount={:?}", drift.wallet.authority(), subaccounts);
 
         drift.subscribe_blockhashes().await.expect("subscribed");
+
+        let subaccount_pubkeys: Vec<Pubkey> = config
+            .get_subaccounts()
+            .iter()
+            .map(|id| drift.wallet.sub_account(*id))
+            .collect();
+
+        let collateral_info_per_subaccount =
+            Arc::new(get_collateral_info_per_subaccount(&drift, &subaccount_pubkeys).await);
+
+        // In flight txs tracking to prevent over committing
+        let (txs_in_flight, free_collateral_per_subaccount) = {
+            let txs = DashMap::new();
+            let free = DashMap::new();
+            for &subaccount in &subaccount_pubkeys {
+                txs.insert(subaccount, HashSet::new());
+                if let Some(info) = collateral_info_per_subaccount.get(&subaccount) {
+                    free.insert(subaccount, info.free.max(0) as u128);
+                }
+            }
+            (Arc::new(txs), Arc::new(free))
+        };
+
+        let tx_sig_to_collateral: Arc<DashMap<Signature, (u128, u64)>> = Arc::new(DashMap::new());
+
+        let tx_worker = TxWorker::new(
+            drift.clone(),
+            Arc::clone(&metrics),
+            config.dry,
+            Some(Arc::clone(&txs_in_flight)),
+            Some(Arc::clone(&tx_sig_to_collateral)),
+            Some(Arc::clone(&free_collateral_per_subaccount)),
+        );
+        let rt = tokio::runtime::Handle::current();
+        let tx_sender = tx_worker.run(rt);
+
         let dlob_notifier = dlob.spawn_notifier();
         let events_rx = setup_grpc(
             drift.clone(),
@@ -486,6 +544,7 @@ impl LiquidatorBot {
                 market_state.set_perp_oracle_price(market.market_index, oracle.data);
             }
         }
+
         for market in drift.program_data().spot_market_configs() {
             market_state.set_spot_market(*market);
             if let Some(oracle) = drift
@@ -514,6 +573,11 @@ impl LiquidatorBot {
 
         log::info!(target: TARGET, "subscribed pyth price feeds");
 
+        let cu_limit = std::env::var("FILL_CU_LIMIT")
+            .ok()
+            .and_then(|s| s.parse::<u32>().ok())
+            .unwrap_or(config.fill_cu_limit);
+
         // start liquidation worker
         let (liq_tx, liq_rx) = tokio::sync::mpsc::channel::<(
             Pubkey,
@@ -525,24 +589,51 @@ impl LiquidatorBot {
         )>(102400);
         spawn_liquidation_worker(
             tx_sender.clone(),
-            // TODO: apply your own liquidation strategy here
-            Arc::new(LiquidateWithMatchStrategy {
+            Arc::new(PrimaryLiquidationStrategy {
                 dlob,
                 drift: drift.clone(),
                 market_state: Arc::clone(&market_state),
-                keeper_subaccount,
+                subaccounts: subaccounts.clone(),
                 metrics: Arc::clone(&metrics),
                 use_spot_liquidation: config.use_spot_liquidation,
+                txs_in_flight: Arc::clone(&txs_in_flight),
+                tx_sig_to_collateral: Arc::clone(&tx_sig_to_collateral),
+                free_collateral_per_subaccount: Arc::clone(&free_collateral_per_subaccount),
             }),
             liq_rx,
-            std::env::var("FILL_CU_LIMIT")
-                .ok()
-                .and_then(|s| s.parse::<u32>().ok())
-                .unwrap_or(config.fill_cu_limit),
+            cu_limit,
             Arc::clone(&priority_fee_subscriber),
         );
 
         log::info!(target: TARGET, "spawned liquidation worker");
+
+        spawn_derisk_loop(
+            drift.clone(),
+            tx_sender.clone(),
+            subaccounts,
+            Arc::clone(&priority_fee_subscriber),
+            cu_limit,
+        );
+
+        log::info!(target: TARGET, "spawned derisk worker");
+
+        let tx_sig_to_collateral_clone = Arc::clone(&tx_sig_to_collateral);
+        let txs_in_flight_clone = Arc::clone(&txs_in_flight);
+        let free_collateral_per_subaccount_clone = Arc::clone(&free_collateral_per_subaccount);
+
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(30));
+            loop {
+                interval.tick().await;
+                clean_stale_in_flight_txs(
+                    Arc::clone(&tx_sig_to_collateral_clone),
+                    Arc::clone(&txs_in_flight_clone),
+                    Arc::clone(&free_collateral_per_subaccount_clone),
+                );
+            }
+        });
+
+        log::info!(target: TARGET, "spawned stale in flight txs cleanup worker");
 
         LiquidatorBot {
             drift,
@@ -553,6 +644,11 @@ impl LiquidatorBot {
             liq_tx,
             pyth_price_feed: Some(pyth_price_feed),
             dashboard_state,
+            subaccount_pubkeys,
+            collateral_info_per_subaccount,
+            txs_in_flight,
+            tx_sig_to_collateral,
+            free_collateral_per_subaccount,
         }
     }
 
@@ -577,6 +673,9 @@ impl LiquidatorBot {
         // initialize local User storage
         let mut exclude_count = 0;
         let mut initial_high_risk_count = 0;
+
+        let mut last_collateral_refresh_ms: u64 = 0;
+        const COLLATERAL_REFRESH_INTERVAL_MS: u64 = 5_000;
 
         log::info!(target: TARGET, "starting user account initialization");
 
@@ -693,6 +792,44 @@ impl LiquidatorBot {
                         user,
                         slot: update_slot,
                     } => {
+                        let now_ms = current_time_millis();
+                        if now_ms.saturating_sub(last_collateral_refresh_ms)
+                            >= COLLATERAL_REFRESH_INTERVAL_MS
+                        {
+                            last_collateral_refresh_ms = now_ms;
+
+                            // Update collaterals
+                            let new_collateral = get_collateral_info_per_subaccount(
+                                &drift,
+                                &self.subaccount_pubkeys,
+                            )
+                            .await;
+
+                            self.collateral_info_per_subaccount.clear();
+
+                            for (subaccount_pubkey, collateral_info) in new_collateral {
+                                self.collateral_info_per_subaccount
+                                    .insert(subaccount_pubkey, collateral_info);
+                            }
+
+                            // Update free collateral accounting for in flight txs
+                            for entry in self.collateral_info_per_subaccount.iter() {
+                                let subaccount_pubkey = entry.key();
+                                let collateral_info = entry.value();
+                                let mut free = collateral_info.free;
+
+                                if let Some(in_flight) = self.txs_in_flight.get(subaccount_pubkey) {
+                                    for sig in in_flight.value().iter() {
+                                        if let Some(reserved) = self.tx_sig_to_collateral.get(sig) {
+                                            free = free.saturating_sub(reserved.value().0 as i128);
+                                        }
+                                    }
+                                }
+                                self.free_collateral_per_subaccount
+                                    .insert(*subaccount_pubkey, free.max(0) as u128);
+                            }
+                        }
+
                         let old_user = users.get(&pubkey).map(|m| &m.user);
                         dlob_notifier.user_update(pubkey, old_user, &user, update_slot);
                         let now_ms = current_time_millis();
@@ -826,7 +963,7 @@ impl LiquidatorBot {
             if oracle_update {
                 let _high_risk_count = high_risk.len();
 
-                let t0 = current_time_millis();
+                let _t0 = current_time_millis();
                 let mut liquidatable_users = Vec::new();
 
                 // Update dashboard state
@@ -950,7 +1087,7 @@ impl LiquidatorBot {
                 // );
 
                 // Update high_risk set synchronously but quickly (just remove safe users)
-                let t0 = current_time_millis();
+                let _t0 = current_time_millis();
                 high_risk.retain(|pubkey| {
                     if let Some(user_meta) = users.get(pubkey) {
                         // Log staleness but still check margin status
@@ -1144,6 +1281,175 @@ impl LiquidatorBot {
     }
 }
 
+fn clean_stale_in_flight_txs(
+    tx_sig_to_collateral: Arc<DashMap<Signature, (u128, u64)>>,
+    txs_in_flight: Arc<DashMap<Pubkey, HashSet<Signature>>>,
+    free_collateral_per_subaccount: Arc<DashMap<Pubkey, u128>>,
+) {
+    let now = current_time_millis();
+    let timeout_ms = 60_000;
+
+    let stale: Vec<(Signature, u128)> = tx_sig_to_collateral
+        .iter()
+        .filter_map(|entry| {
+            if now.saturating_sub(entry.value().1) > timeout_ms {
+                Some((*entry.key(), entry.value().0))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    for (sig, collateral) in stale {
+        tx_sig_to_collateral.remove(&sig);
+        for mut entry in txs_in_flight.iter_mut() {
+            if entry.value_mut().remove(&sig) {
+                if let Some(mut free) = free_collateral_per_subaccount.get_mut(entry.key()) {
+                    *free = free.saturating_add(collateral);
+                }
+                break;
+            }
+        }
+    }
+}
+
+async fn derisk_subaccount(
+    drift: &DriftClient,
+    tx_sender: &TxSender,
+    subaccount: Pubkey,
+    priority_fee: u64,
+    cu_limit: u32,
+) {
+    let user = match drift.try_get_account::<User>(&subaccount) {
+        Ok(u) => u,
+        Err(_) => return,
+    };
+
+    for position in user.perp_positions.iter() {
+        if position.base_asset_amount == 0 && position.quote_asset_amount == 0 {
+            continue;
+        }
+
+        let mut tx_builder = TransactionBuilder::new(
+            drift.program_data(),
+            subaccount,
+            std::borrow::Cow::Owned(user.clone()),
+            false,
+        )
+        .with_priority_fee(priority_fee, Some(cu_limit));
+
+        if position.base_asset_amount != 0 {
+            let direction = if position.base_asset_amount > 0 {
+                PositionDirection::Short
+            } else {
+                PositionDirection::Long
+            };
+
+            tx_builder = tx_builder.place_orders(vec![OrderParams {
+                order_type: OrderType::Market,
+                market_type: MarketType::Perp,
+                direction,
+                base_asset_amount: position.base_asset_amount.unsigned_abs(),
+                market_index: position.market_index,
+                reduce_only: true,
+                max_ts: Some((current_time_millis() / 1000 + 5) as i64), // ~5s
+                ..Default::default()
+            }]);
+
+            tx_sender
+                .send_tx(
+                    tx_builder.build(),
+                    TxIntent::Derisk {
+                        market_index: position.market_index,
+                        subaccount,
+                    },
+                    cu_limit as u64,
+                )
+                .await;
+        } else {
+            tx_builder = tx_builder.settle_pnl(position.market_index, None, None);
+
+            tx_sender
+                .send_tx(
+                    tx_builder.build(),
+                    TxIntent::SettlePnl {
+                        market_index: position.market_index,
+                        subaccount,
+                    },
+                    cu_limit as u64,
+                )
+                .await;
+        }
+    }
+
+    // TODO: Add spot derisking, swap any position back to USDC using jupiter/titan
+}
+
+fn spawn_derisk_loop(
+    drift: DriftClient,
+    tx_sender: TxSender,
+    subaccounts: Vec<Pubkey>,
+    priority_fee_subscriber: Arc<PriorityFeeSubscriber>,
+    cu_limit: u32,
+) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(5));
+        loop {
+            interval.tick().await;
+            let priority_fee = priority_fee_subscriber.priority_fee_nth(0.6);
+            for subaccount in &subaccounts {
+                derisk_subaccount(&drift, &tx_sender, *subaccount, priority_fee, cu_limit).await;
+            }
+        }
+    });
+}
+
+async fn get_collateral_info_per_subaccount(
+    drift: &DriftClient,
+    subaccounts: &[Pubkey],
+) -> DashMap<Pubkey, CollateralInfo> {
+    let collateral_info_per_subaccount = DashMap::<Pubkey, CollateralInfo>::new();
+    for &subaccount_pubkey in subaccounts {
+        match drift.get_user_account(&subaccount_pubkey).await {
+            Ok(user_account) => {
+                match calculate_collateral(
+                    &drift,
+                    &user_account,
+                    MarginRequirementType::Maintenance,
+                ) {
+                    Ok(collateral_info) => {
+                        collateral_info_per_subaccount.insert(subaccount_pubkey, collateral_info);
+                        log::info!(
+                            target: TARGET,
+                            "Subaccount {}: free_collateral = {}, total_collateral = {}",
+                            subaccount_pubkey,
+                            collateral_info.free,
+                            collateral_info.total
+                        );
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            target: TARGET,
+                            "Failed to calculate collateral for subaccount {}: {:?}",
+                            subaccount_pubkey,
+                            e
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                log::warn!(
+                    target: TARGET,
+                    "Failed to load subaccount {}: {:?}",
+                    subaccount_pubkey,
+                    e
+                );
+            }
+        }
+    }
+    collateral_info_per_subaccount
+}
+
 fn on_transaction_update_fn(
     tx_sender: TxSender,
 ) -> impl Fn(&TransactionUpdate) + Send + Sync + 'static {
@@ -1301,76 +1607,6 @@ async fn setup_grpc(
     rx
 }
 
-/// Try to fill liquidation with order match
-fn try_liquidate_with_match(
-    drift: &DriftClient,
-    market_index: u16,
-    keeper_subaccount: Pubkey,
-    liquidatee_subaccount: Pubkey,
-    top_makers: &[User],
-    tx_sender: TxSender,
-    priority_fee: u64,
-    cu_limit: u32,
-    slot: u64,
-    pyth_price_update: Option<PythPriceUpdate>,
-) {
-    if top_makers.is_empty() {
-        log::debug!(target: TARGET, "skip empty maker cross. market={market_index} user={liquidatee_subaccount}");
-        return;
-    }
-
-    let keeper_account_data = drift.try_get_account::<User>(&keeper_subaccount);
-    if keeper_account_data.is_err() {
-        log::debug!(target: TARGET, "keeper acc lookup failed={keeper_subaccount:?}");
-        return;
-    }
-    let liquidatee_subaccount_data = drift.try_get_account::<User>(&liquidatee_subaccount);
-    if liquidatee_subaccount_data.is_err() {
-        log::debug!(target: TARGET, "liquidatee acc lookup failed={liquidatee_subaccount:?}");
-        return;
-    }
-
-    let mut tx_builder = TransactionBuilder::new(
-        drift.program_data(),
-        keeper_subaccount,
-        std::borrow::Cow::Owned(keeper_account_data.unwrap()),
-        false,
-    )
-    .with_priority_fee(priority_fee, Some(cu_limit));
-
-    if let Some(ref update) = pyth_price_update {
-        tx_builder = tx_builder.post_pyth_lazer_oracle_update(&[update.feed_id], &update.message);
-    }
-
-    tx_builder = tx_builder.liquidate_perp_with_fill(
-        market_index,
-        &liquidatee_subaccount_data.unwrap(),
-        top_makers,
-    );
-
-    // large accounts list, bump CU limit to compensate
-    if let Some(ix) = tx_builder.ixs().last() {
-        if ix.accounts.len() >= 20 {
-            tx_builder = tx_builder.set_ix(
-                1,
-                ComputeBudgetInstruction::set_compute_unit_limit(cu_limit * 2),
-            );
-        }
-    }
-
-    let tx = tx_builder.build();
-
-    tx_sender.send_tx(
-        tx,
-        TxIntent::LiquidateWithFill {
-            market_index,
-            liquidatee: liquidatee_subaccount,
-            slot,
-        },
-        cu_limit as u64,
-    );
-}
-
 fn spawn_liquidation_worker(
     tx_sender: TxSender,
     strategy: Arc<dyn LiquidationStrategy + Send + Sync>,
@@ -1472,18 +1708,544 @@ fn spawn_liquidation_worker(
     });
 }
 
-/// Default liquidation strategy that matches against top-of-book makers and
-/// submits liquidate_with_fill
-pub struct LiquidateWithMatchStrategy {
+enum LiquidationType {
+    SettlePnl,
+    PerpWithFill,
+    PerpTakeover,
+    PerpPnlForDeposit,
+    BorrowForPerpPnl,
+    SpotForSpot,
+    Skip,
+}
+
+#[derive(Debug, Clone)]
+struct PositionInfo {
+    market_type: MarketType,
+    market_index: u16,
+    is_asset: bool,
+    collateral_required: i128,
+    base_amount: i64,
+    quote_amount: i64,
+}
+
+/// Primary liquidation strategy
+pub struct PrimaryLiquidationStrategy {
     pub drift: DriftClient,
     pub dlob: &'static DLOB,
     pub market_state: Arc<RwLock<MarketState>>,
-    pub keeper_subaccount: Pubkey,
+    pub subaccounts: Vec<Pubkey>,
     pub metrics: Arc<Metrics>,
     pub use_spot_liquidation: bool,
+    pub txs_in_flight: Arc<DashMap<Pubkey, HashSet<Signature>>>,
+    // Map(Signature,(collateral, ts))
+    pub tx_sig_to_collateral: Arc<DashMap<Signature, (u128, u64)>>,
+    pub free_collateral_per_subaccount: Arc<DashMap<Pubkey, u128>>,
 }
 
-impl LiquidateWithMatchStrategy {
+impl PrimaryLiquidationStrategy {
+    /// Liquidation policy: Prefer takeover for small positions, use makers for large positions,
+    /// fallback to takeover when no makers available. Skip if no makers and insufficient collateral.
+    fn decide_perp_method(
+        quote_asset_amount: u64,
+        collateral_available: u128,
+        collateral_required: u128,
+        has_makers: bool,
+    ) -> LiquidationType {
+        // const POSITION_AMOUNT_THRESHOLD: u64 = 5_000 * QUOTE_PRECISION_U64;
+
+        // let is_small_position = quote_asset_amount <= POSITION_AMOUNT_THRESHOLD;
+        // let can_afford_takeover = collateral_available >= collateral_required;
+
+        // if is_small_position && can_afford_takeover {
+        //     LiquidationType::PerpTakeover
+        // } else if has_makers {
+        //     LiquidationType::PerpWithFill
+        // } else if can_afford_takeover {
+        //     LiquidationType::PerpTakeover
+        // } else {
+        //     LiquidationType::Skip
+        // }
+
+        // For testing just use Fill
+        LiquidationType::PerpWithFill
+    }
+
+    fn decide_liquidation_type(
+        liability: &PositionInfo,
+        asset: Option<&PositionInfo>,
+        has_pnl_only: bool,
+    ) -> LiquidationType {
+        if has_pnl_only {
+            return LiquidationType::SettlePnl;
+        }
+        match (liability.market_type, asset.map(|a| a.market_type)) {
+            (MarketType::Perp, None) => LiquidationType::PerpTakeover,
+            (MarketType::Perp, Some(MarketType::Spot)) => LiquidationType::PerpPnlForDeposit,
+            (MarketType::Spot, Some(MarketType::Perp)) => LiquidationType::BorrowForPerpPnl,
+            (MarketType::Spot, Some(MarketType::Spot)) => LiquidationType::SpotForSpot,
+            _ => LiquidationType::Skip,
+        }
+    }
+
+    fn calculate_perp_collateral_requirement(
+        market_state: Arc<RwLock<MarketState>>,
+        market_index: u16,
+        base_asset_amount: i64,
+    ) -> Option<u128> {
+        let state = market_state.read().unwrap().load();
+
+        let perp_market = state.perp_markets.get(&market_index)?;
+        let oracle = state.perp_oracle_prices.get(&market_index)?;
+
+        let margin_ratio = perp_market
+            .get_margin_ratio(
+                base_asset_amount.unsigned_abs() as u128,
+                MarginRequirementType::Initial,
+                false,
+            )
+            .ok()?;
+
+        let collateral = (base_asset_amount.abs() as u128)
+            .saturating_mul(oracle.price as u128)
+            .saturating_mul(QUOTE_PRECISION)
+            .saturating_mul(margin_ratio as u128)
+            .saturating_div(MARGIN_PRECISION_U128)
+            .saturating_div(PRICE_PRECISION)
+            .saturating_div(BASE_PRECISION);
+
+        Some(collateral)
+    }
+
+    fn extract_collateral_params(
+        market_state: Arc<RwLock<MarketState>>,
+        liability: &PositionInfo,
+        asset: &PositionInfo,
+    ) -> (i64, u128, u128, u128, i64, u128, u128, u128) {
+        let state = market_state.read().unwrap().load();
+
+        let (liability_oracle, liability_precision) = if liability.market_type == MarketType::Spot {
+            let oracle = state
+                .spot_oracle_prices
+                .get(&liability.market_index)
+                .expect("liability oracle");
+            let market = state
+                .spot_markets
+                .get(&liability.market_index)
+                .expect("liability market");
+            (oracle.price, 10_u128.pow(market.decimals))
+        } else {
+            let oracle = state.spot_oracle_prices.get(&0).expect("USDC oracle");
+            (oracle.price, QUOTE_PRECISION)
+        };
+
+        let liability_weight = if liability.market_type == MarketType::Spot {
+            let market = state
+                .spot_markets
+                .get(&liability.market_index)
+                .expect("liability spot market");
+            market.initial_liability_weight as u128
+        } else {
+            1u128
+        };
+
+        let (asset_oracle, asset_precision) = if asset.market_type == MarketType::Spot {
+            let oracle = state
+                .spot_oracle_prices
+                .get(&asset.market_index)
+                .expect("asset oracle");
+            let market = state
+                .spot_markets
+                .get(&asset.market_index)
+                .expect("asset market");
+            (oracle.price, 10_u128.pow(market.decimals))
+        } else {
+            let oracle = state.spot_oracle_prices.get(&0).expect("USDC oracle");
+            (oracle.price, QUOTE_PRECISION)
+        };
+
+        let (asset_weight, asset_weight_precision) = if asset.market_type == MarketType::Spot {
+            let market = state
+                .spot_markets
+                .get(&asset.market_index)
+                .expect("asset spot market");
+            (
+                market.initial_asset_weight as u128,
+                SPOT_WEIGHT_PRECISION_U128,
+            )
+        } else {
+            (SPOT_WEIGHT_PRECISION_U128, SPOT_WEIGHT_PRECISION_U128)
+        };
+
+        (
+            liability_oracle,
+            liability_precision,
+            liability_weight,
+            SPOT_WEIGHT_PRECISION_U128,
+            asset_oracle,
+            asset_precision,
+            asset_weight,
+            asset_weight_precision,
+        )
+    }
+
+    fn calculate_net_collateral_requirement_with_params(
+        liability_size: u128,
+        liability: &PositionInfo,
+        asset: &PositionInfo,
+        liability_oracle_price: i64,
+        liability_precision: u128,
+        liability_weight: u128,
+        liability_weight_precision: u128,
+        asset_oracle_price: i64,
+        asset_precision: u128,
+        asset_weight: u128,
+        asset_weight_precision: u128,
+    ) -> i128 {
+        let asset_amount_back_in_tokens = liability_size
+            .saturating_mul(liability_oracle_price as u128)
+            .saturating_div(asset_oracle_price as u128)
+            .saturating_mul(asset_precision)
+            .saturating_div(liability_precision);
+
+        let asset_amount_back_in_collateral = asset_amount_back_in_tokens
+            .saturating_mul(asset_oracle_price as u128)
+            .saturating_mul(QUOTE_PRECISION)
+            .saturating_mul(asset_weight)
+            .saturating_div(asset_weight_precision)
+            .saturating_div(asset_precision)
+            .saturating_div(PRICE_PRECISION);
+
+        let liability_collateral_impact = if liability.market_type == MarketType::Spot {
+            liability_size
+                .saturating_mul(liability_oracle_price as u128)
+                .saturating_div(PRICE_PRECISION)
+                .saturating_mul(QUOTE_PRECISION)
+                .saturating_div(liability_precision)
+                .saturating_mul(liability_weight)
+                .saturating_div(liability_weight_precision)
+        } else {
+            liability
+                .collateral_required
+                .unsigned_abs()
+                .min(liability_size)
+        };
+
+        let net_impact = liability_collateral_impact.saturating_sub(
+            asset_amount_back_in_collateral.min(asset.collateral_required.unsigned_abs()),
+        );
+
+        net_impact as i128
+    }
+
+    fn calculate_net_collateral_requirement(
+        liability_size: u128,
+        liability: &PositionInfo,
+        asset: &PositionInfo,
+        market_state: Arc<RwLock<MarketState>>,
+    ) -> i128 {
+        let (l_oracle, l_prec, l_weight, l_weight_prec, a_oracle, a_prec, a_weight, a_weight_prec) =
+            Self::extract_collateral_params(market_state, liability, asset);
+
+        Self::calculate_net_collateral_requirement_with_params(
+            liability_size,
+            liability,
+            asset,
+            l_oracle,
+            l_prec,
+            l_weight,
+            l_weight_prec,
+            a_oracle,
+            a_prec,
+            a_weight,
+            a_weight_prec,
+        )
+    }
+
+    /// finds the max liquidation amount whose collateral impact fits within available collateral,
+    /// allowing unused collateral up to `tolerance`.
+    fn find_max_liq_amount<F>(
+        max_amount: u128,
+        available_collateral: i128,
+        tolerance: i128,
+        impact_fn: F,
+    ) -> u128
+    where
+        F: Fn(u128) -> i128,
+    {
+        let mut low = 0u128;
+        let mut high = max_amount;
+        let mut best = 0u128;
+
+        while low <= high {
+            let mid = (low + high) / 2;
+            let impact = impact_fn(mid);
+            let difference = available_collateral - impact;
+
+            if difference < 0 {
+                if mid == 0 {
+                    break;
+                }
+                high = mid - 1;
+            } else {
+                best = mid;
+
+                if difference > tolerance {
+                    low = mid + 1;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        best
+    }
+
+    /// Calculate collateral requirement for all perp positions
+    fn get_perp_positions_info(
+        market_state: Arc<RwLock<MarketState>>,
+        perp_positions: &[PerpPosition],
+    ) -> Vec<PositionInfo> {
+        let state = market_state.read().unwrap().load();
+
+        perp_positions
+            .iter()
+            .filter(|p| p.base_asset_amount != 0 || p.quote_asset_amount != 0)
+            .filter_map(|pos| {
+                let perp_market = state.perp_markets.get(&pos.market_index)?;
+                let oracle = state.perp_oracle_prices.get(&pos.market_index)?;
+
+                if pos.base_asset_amount == 0 && pos.quote_asset_amount != 0 && pos.lp_shares == 0 {
+                    let usdc = state.spot_markets.get(&0)?;
+
+                    let claimable_pnl_available =
+                        match calculate_claimable_pnl(perp_market, usdc, pos, oracle.price) {
+                            Ok(pnl) => pnl.abs(),
+                            Err(_) => 0,
+                        };
+
+                    Some(PositionInfo {
+                        market_type: MarketType::Perp,
+                        market_index: pos.market_index,
+                        is_asset: claimable_pnl_available > 0,
+                        collateral_required: claimable_pnl_available as i128,
+                        base_amount: 0,
+                        quote_amount: pos.quote_asset_amount,
+                    })
+                } else {
+                    let margin_ratio = perp_market
+                        .get_margin_ratio(
+                            pos.base_asset_amount.unsigned_abs() as u128,
+                            MarginRequirementType::Initial,
+                            false,
+                        )
+                        .ok()?;
+
+                    let collateral = (pos.base_asset_amount.abs() as u128)
+                        .saturating_mul(oracle.price as u128)
+                        .saturating_mul(QUOTE_PRECISION)
+                        .saturating_mul(margin_ratio as u128)
+                        .saturating_div(MARGIN_PRECISION_U128)
+                        .saturating_div(PRICE_PRECISION)
+                        .saturating_div(BASE_PRECISION);
+
+                    Some(PositionInfo {
+                        market_type: MarketType::Perp,
+                        market_index: pos.market_index,
+                        is_asset: pos.quote_asset_amount > 0,
+                        collateral_required: collateral as i128,
+                        base_amount: pos.base_asset_amount,
+                        quote_amount: pos.quote_asset_amount,
+                    })
+                }
+            })
+            .collect()
+    }
+
+    /// Calculate collateral required for all spot positions
+    fn get_spot_positions_info(
+        market_state: Arc<RwLock<MarketState>>,
+        spot_positions: &[SpotPosition],
+    ) -> Vec<PositionInfo> {
+        let state = market_state.read().unwrap().load();
+
+        spot_positions
+            .iter()
+            .filter(|p| !p.is_available())
+            .filter_map(|pos| {
+                let spot_market = state.spot_markets.get(&pos.market_index)?;
+                let oracle = state.spot_oracle_prices.get(&pos.market_index)?;
+
+                let token_amount = pos.get_signed_token_amount(&spot_market).ok()?;
+
+                let token_precision = 10_u128.pow(spot_market.decimals);
+                let weight = if pos.balance_type == SpotBalanceType::Deposit {
+                    spot_market.initial_asset_weight
+                } else {
+                    spot_market.initial_liability_weight
+                };
+
+                let collateral_impact = (token_amount.abs() as u128)
+                    .saturating_mul(oracle.price as u128)
+                    .saturating_div(PRICE_PRECISION)
+                    .saturating_mul(QUOTE_PRECISION)
+                    .saturating_div(token_precision)
+                    .saturating_mul(weight as u128)
+                    .saturating_div(SPOT_WEIGHT_PRECISION_U128);
+
+                Some(PositionInfo {
+                    market_type: MarketType::Spot,
+                    market_index: pos.market_index,
+                    is_asset: pos.balance_type == SpotBalanceType::Deposit,
+                    collateral_required: collateral_impact as i128,
+                    base_amount: token_amount as i64,
+                    quote_amount: 0,
+                })
+            })
+            .collect()
+    }
+
+    // Port of  https://github.com/drift-labs/protocol-v2/blob/master/sdk/src/user.ts#L3941-L3971
+    fn get_safest_tiers(user_account: &User, drift: &DriftClient) -> (u8, u8) {
+        let mut safest_perp_tier = 4;
+        let mut safest_spot_tier = 4;
+
+        for perp_position in user_account
+            .perp_positions
+            .iter()
+            .filter(|p| !p.is_available())
+        {
+            if let Some(perp_market) = drift
+                .program_data()
+                .perp_market_config_by_index(perp_position.market_index)
+            {
+                safest_perp_tier = safest_perp_tier.min(perp_market.contract_tier.to_number());
+            }
+        }
+
+        for spot_position in user_account
+            .spot_positions
+            .iter()
+            .filter(|p| !p.is_available() && p.balance_type != SpotBalanceType::Deposit)
+        {
+            if let Some(spot_market) = drift
+                .program_data()
+                .spot_market_config_by_index(spot_position.market_index)
+            {
+                safest_spot_tier = safest_spot_tier.min(spot_market.asset_tier.to_number());
+            }
+        }
+
+        (safest_perp_tier, safest_spot_tier)
+    }
+
+    /// Pick the largest liability and best matching asset
+    fn pick_best_asset_liability_combo(
+        market_state: Arc<RwLock<MarketState>>,
+        perp_positions: &[PositionInfo],
+        spot_positions: &[PositionInfo],
+        safest_perp_tier: u8,
+        safest_spot_tier: u8,
+    ) -> Option<(PositionInfo, Option<PositionInfo>)> {
+        let state = market_state.read().unwrap().load();
+
+        let (mut liabilities, mut assets): (Vec<PositionInfo>, Vec<PositionInfo>) = perp_positions
+            .iter()
+            .chain(spot_positions)
+            .cloned()
+            .partition(|p| !p.is_asset);
+
+        liabilities.sort_by(|a, b| {
+            b.collateral_required
+                .abs()
+                .cmp(&a.collateral_required.abs())
+        });
+
+        assets.sort_by(|a, b| {
+            b.collateral_required
+                .abs()
+                .cmp(&a.collateral_required.abs())
+        });
+
+        let largest_liability = liabilities.into_iter().find(|liability| {
+            if liability.market_type == MarketType::Spot {
+                true
+            } else {
+                match state.perp_markets.get(&liability.market_index) {
+                    Some(perp_market) => perp_tier_is_as_safe_as(
+                        perp_market.contract_tier.to_number(),
+                        safest_perp_tier,
+                        safest_spot_tier,
+                    ),
+                    None => false,
+                }
+            }
+        })?;
+
+        let best_asset = assets.first().cloned();
+
+        Some((largest_liability, best_asset))
+    }
+
+    /// Returns the subaccount with most free collateral that has position room
+    fn find_best_subaccount_for_liquidation(
+        drift: &DriftClient,
+        subaccounts: &[Pubkey],
+        needs_perp_room: bool,
+        needs_spot_room: bool,
+        free_collateral_per_subaccount: &DashMap<Pubkey, u128>,
+        min_collateral_required: u128,
+    ) -> Option<Pubkey> {
+        let mut candidates: Vec<(Pubkey, u128)> = subaccounts
+            .iter()
+            .filter_map(|&subaccount| {
+                let Some(free_collateral_info) = free_collateral_per_subaccount.get(&subaccount)
+                else {
+                    return None;
+                };
+
+                if *free_collateral_info < min_collateral_required {
+                    return None;
+                }
+
+                let user = drift.try_get_account::<User>(&subaccount).ok()?;
+
+                if needs_perp_room {
+                    let active_perp_positions = user
+                        .perp_positions
+                        .iter()
+                        .filter(|p| p.base_asset_amount != 0 || p.quote_asset_amount != 0)
+                        .count();
+
+                    if active_perp_positions >= 8 {
+                        return None;
+                    }
+                }
+
+                if needs_spot_room {
+                    let active_spot_positions = user
+                        .spot_positions
+                        .iter()
+                        .filter(|p| !p.is_available())
+                        .count();
+
+                    if active_spot_positions >= 8 {
+                        return None;
+                    }
+                }
+
+                Some((subaccount, *free_collateral_info))
+            })
+            .collect();
+
+        if candidates.is_empty() {
+            return None;
+        }
+
+        candidates.sort_by_key(|&(_, free_collateral)| std::cmp::Reverse(free_collateral));
+
+        Some(candidates[0].0)
+    }
+
     /// Find top makers for a perp position
     fn find_top_makers(
         drift: &DriftClient,
@@ -1537,13 +2299,175 @@ impl LiquidateWithMatchStrategy {
         Some(makers)
     }
 
-    /// Attempt perp liquidation with order matching
-    fn liquidate_perp(
+    /// Try to fill liquidation with order match
+    async fn try_liquidate_with_match(
+        drift: &DriftClient,
+        market_index: u16,
+        subaccount: Pubkey,
+        liquidatee_subaccount: Pubkey,
+        top_makers: &[User],
+        tx_sender: TxSender,
+        priority_fee: u64,
+        cu_limit: u32,
+        slot: u64,
+        pyth_price_update: Option<PythPriceUpdate>,
+    ) {
+        if top_makers.is_empty() {
+            log::debug!(target: TARGET, "skip empty maker cross. market={market_index} user={liquidatee_subaccount}");
+            return;
+        }
+
+        let keeper_account_data = drift.try_get_account::<User>(&subaccount);
+        if keeper_account_data.is_err() {
+            log::debug!(target: TARGET, "keeper acc lookup failed={subaccount:?}");
+            return;
+        }
+        let liquidatee_subaccount_data = drift.try_get_account::<User>(&liquidatee_subaccount);
+        if liquidatee_subaccount_data.is_err() {
+            log::debug!(target: TARGET, "liquidatee acc lookup failed={liquidatee_subaccount:?}");
+            return;
+        }
+
+        let mut tx_builder = TransactionBuilder::new(
+            drift.program_data(),
+            subaccount,
+            std::borrow::Cow::Owned(keeper_account_data.unwrap()),
+            false,
+        )
+        .with_priority_fee(priority_fee, Some(cu_limit));
+
+        if let Some(ref update) = pyth_price_update {
+            tx_builder =
+                tx_builder.post_pyth_lazer_oracle_update(&[update.feed_id], &update.message);
+        }
+
+        tx_builder = tx_builder.liquidate_perp_with_fill(
+            market_index,
+            &liquidatee_subaccount_data.unwrap(),
+            top_makers,
+        );
+
+        // large accounts list, bump CU limit to compensate
+        if let Some(ix) = tx_builder.ixs().last() {
+            if ix.accounts.len() >= 20 {
+                tx_builder = tx_builder.set_ix(
+                    1,
+                    ComputeBudgetInstruction::set_compute_unit_limit(cu_limit * 2),
+                );
+            }
+        }
+
+        let tx = tx_builder.build();
+
+        // Fill doesn't require collateral management
+        tx_sender
+            .send_tx(
+                tx,
+                TxIntent::LiquidateWithFill {
+                    market_index,
+                    liquidatee: liquidatee_subaccount,
+                    slot,
+                },
+                cu_limit as u64,
+            )
+            .await;
+    }
+
+    /// Try to liquidate by taking over position
+    async fn try_liquidate_with_collateral(
+        &self,
+        drift: &DriftClient,
+        market_index: u16,
+        subaccount: Pubkey,
+        liquidatee_subaccount: Pubkey,
+        base_asset_amount: u64,
+        collateral_required: u128,
+        tx_sender: TxSender,
+        priority_fee: u64,
+        cu_limit: u32,
+        slot: u64,
+        pyth_price_update: Option<PythPriceUpdate>,
+    ) {
+        let keeper_account_data = drift.try_get_account::<User>(&subaccount);
+        if keeper_account_data.is_err() {
+            log::debug!(target: TARGET, "keeper acc lookup failed={subaccount:?}");
+            return;
+        }
+        let liquidatee_subaccount_data = drift.try_get_account::<User>(&liquidatee_subaccount);
+        if liquidatee_subaccount_data.is_err() {
+            log::debug!(target: TARGET, "liquidatee acc lookup failed={liquidatee_subaccount:?}");
+            return;
+        }
+
+        let mut tx_builder = TransactionBuilder::new(
+            drift.program_data(),
+            subaccount,
+            std::borrow::Cow::Owned(keeper_account_data.unwrap()),
+            false,
+        )
+        .with_priority_fee(priority_fee, Some(cu_limit));
+
+        if let Some(ref update) = pyth_price_update {
+            tx_builder =
+                tx_builder.post_pyth_lazer_oracle_update(&[update.feed_id], &update.message);
+        }
+
+        tx_builder = tx_builder.liquidate_perp(
+            market_index,
+            &liquidatee_subaccount_data.unwrap(),
+            base_asset_amount,
+            None,
+        );
+
+        // large accounts list, bump CU limit to compensate
+        if let Some(ix) = tx_builder.ixs().last() {
+            if ix.accounts.len() >= 20 {
+                tx_builder = tx_builder.set_ix(
+                    1,
+                    ComputeBudgetInstruction::set_compute_unit_limit(cu_limit * 2),
+                );
+            }
+        }
+
+        let tx = tx_builder.build();
+
+        match tx_sender
+            .send_tx(
+                tx,
+                TxIntent::LiquidatePerp {
+                    market_index,
+                    liquidatee: liquidatee_subaccount,
+                    slot,
+                },
+                cu_limit as u64,
+            )
+            .await
+        {
+            Some(sig) => {
+                self.txs_in_flight
+                    .entry(subaccount)
+                    .or_insert_with(HashSet::new)
+                    .insert(sig);
+
+                self.tx_sig_to_collateral
+                    .insert(sig, (base_asset_amount as u128, current_time_millis()));
+
+                if let Some(mut free) = self.free_collateral_per_subaccount.get_mut(&subaccount) {
+                    *free = free.saturating_sub(collateral_required);
+                }
+            }
+            None => return,
+        };
+    }
+
+    /// Attempt perp liquidation with order matching or collateral
+    async fn liquidate_perp(
+        &self,
         drift: &DriftClient,
         dlob: &'static DLOB,
         market_state: Arc<RwLock<MarketState>>,
         metrics: Arc<Metrics>,
-        keeper_subaccount: Pubkey,
+        subaccounts: &[Pubkey],
         liquidatee: Pubkey,
         user_account: Arc<User>,
         tx_sender: TxSender,
@@ -1553,6 +2477,11 @@ impl LiquidateWithMatchStrategy {
         pyth_price_update: Option<PythPriceUpdate>,
         status: &UserMarginStatus,
     ) {
+        let Some(subaccount) = subaccounts.first() else {
+            log::warn!(target: TARGET, "no subaccount configured");
+            return;
+        };
+
         // Check isolated liquidations first
         for (market_index, iso_status) in &status.isolated {
             if *iso_status == MarginStatus::Liquidatable {
@@ -1594,10 +2523,10 @@ impl LiquidateWithMatchStrategy {
                     let pyth_update =
                         pyth_price_update.filter(|update| update.price != oracle_price);
 
-                    try_liquidate_with_match(
+                    Self::try_liquidate_with_match(
                         drift,
                         *market_index,
-                        keeper_subaccount,
+                        *subaccount,
                         liquidatee,
                         makers.as_slice(),
                         tx_sender,
@@ -1605,7 +2534,8 @@ impl LiquidateWithMatchStrategy {
                         cu_limit,
                         slot,
                         pyth_update,
-                    );
+                    )
+                    .await;
                     return;
                 }
             }
@@ -1625,21 +2555,23 @@ impl LiquidateWithMatchStrategy {
             return;
         };
 
-        metrics
-            .liquidation_attempts
-            .with_label_values(&["perp"])
-            .inc();
-
-        let Some(makers) = Self::find_top_makers(
-            drift,
-            dlob,
+        // Calculate collateral required
+        let Some(collateral_required) = Self::calculate_perp_collateral_requirement(
             Arc::clone(&market_state),
             pos.market_index,
             pos.base_asset_amount,
         ) else {
+            log::warn!(target: TARGET, "failed to calculate collateral requirement for market {}", pos.market_index);
             return;
         };
 
+        // Check available collateral
+        let Some(free_collateral) = self.free_collateral_per_subaccount.get(&subaccount) else {
+            log::warn!(target: TARGET, "no free collateral for keeper subaccount");
+            return;
+        };
+
+        // Get oracle price and pyth update once
         let oracle_price = {
             let state = market_state.read().unwrap();
             match state.get_perp_oracle_price(pos.market_index) {
@@ -1651,20 +2583,92 @@ impl LiquidateWithMatchStrategy {
             }
         };
 
+        // Find makers and decide method
+        let makers = Self::find_top_makers(
+            drift,
+            dlob,
+            Arc::clone(&market_state),
+            pos.market_index,
+            pos.base_asset_amount,
+        );
+
         let pyth_update = pyth_price_update.filter(|update| update.price != oracle_price);
 
-        try_liquidate_with_match(
-            &drift,
-            pos.market_index,
-            keeper_subaccount,
-            liquidatee,
-            makers.as_slice(),
-            tx_sender,
-            priority_fee,
-            cu_limit,
-            slot,
-            pyth_update,
+        let method = Self::decide_perp_method(
+            pos.quote_asset_amount.try_into().unwrap(),
+            *free_collateral,
+            collateral_required,
+            makers.is_some(),
         );
+
+        metrics
+            .liquidation_attempts
+            .with_label_values(&["perp"])
+            .inc();
+
+        match method {
+            LiquidationType::PerpWithFill => {
+                Self::try_liquidate_with_match(
+                    drift,
+                    pos.market_index,
+                    *subaccount,
+                    liquidatee,
+                    makers.unwrap().as_slice(),
+                    tx_sender,
+                    priority_fee,
+                    cu_limit,
+                    slot,
+                    pyth_update,
+                )
+                .await;
+            }
+            LiquidationType::PerpTakeover => {
+                let Some(subaccount) = Self::find_best_subaccount_for_liquidation(
+                    drift,
+                    subaccounts,
+                    true,
+                    false,
+                    &self.free_collateral_per_subaccount,
+                    collateral_required,
+                ) else {
+                    log::warn!(target: TARGET, "no subaccount available for takeover");
+                    return;
+                };
+
+                let Some(free_collateral) = self.free_collateral_per_subaccount.get(&subaccount)
+                else {
+                    log::warn!(target: TARGET, "no free collateral for subaccount");
+                    return;
+                };
+
+                let base_amount_to_liquidate = if *free_collateral >= collateral_required {
+                    pos.base_asset_amount.unsigned_abs()
+                } else {
+                    let scaled_collateral = (*free_collateral as f64 * 0.9) as u128;
+                    let scale_factor = scaled_collateral as f64 / collateral_required as f64;
+                    (pos.base_asset_amount.unsigned_abs() as f64 * scale_factor) as u64
+                };
+
+                Self::try_liquidate_with_collateral(
+                    &self,
+                    &drift,
+                    pos.market_index,
+                    subaccount,
+                    liquidatee,
+                    base_amount_to_liquidate,
+                    collateral_required,
+                    tx_sender,
+                    priority_fee,
+                    cu_limit,
+                    slot,
+                    pyth_update,
+                )
+                .await;
+            }
+            _ => {
+                log::info!(target: TARGET, "skipping liquidation for {:?}", liquidatee);
+            }
+        }
     }
 
     /// Attempt spot liquidation with Jupiter swap
@@ -1672,7 +2676,7 @@ impl LiquidateWithMatchStrategy {
         drift: DriftClient,
         metrics: Arc<Metrics>,
         market_state: Arc<RwLock<MarketState>>,
-        keeper_subaccount: Pubkey,
+        subaccounts: &[Pubkey],
         liquidatee: Pubkey,
         user_account: Arc<User>,
         tx_sender: TxSender,
@@ -1681,6 +2685,10 @@ impl LiquidateWithMatchStrategy {
         slot: u64,
     ) {
         let authority = drift.wallet.authority();
+        let Some(subaccount) = subaccounts.first() else {
+            log::warn!(target: TARGET, "no subaccount configured");
+            return;
+        };
 
         for pos in user_account
             .spot_positions
@@ -1743,10 +2751,10 @@ impl LiquidateWithMatchStrategy {
             );
 
             // Fetch accounts once
-            let keeper_account_data = match drift.try_get_account::<User>(&keeper_subaccount) {
+            let keeper_account_data = match drift.try_get_account::<User>(&subaccount) {
                 Ok(data) => data,
                 Err(_) => {
-                    log::info!(target: TARGET, "keeper account not found: {:?}", &keeper_subaccount);
+                    log::info!(target: TARGET, "keeper account not found: {:?}", &subaccount);
                     continue;
                 }
             };
@@ -1843,7 +2851,7 @@ impl LiquidateWithMatchStrategy {
             let tx = if use_titan {
                 TransactionBuilder::new(
                     drift.program_data(),
-                    keeper_subaccount,
+                    *subaccount,
                     std::borrow::Cow::Owned(keeper_account_data),
                     false,
                 )
@@ -1862,7 +2870,7 @@ impl LiquidateWithMatchStrategy {
             } else {
                 TransactionBuilder::new(
                     drift.program_data(),
-                    keeper_subaccount,
+                    *subaccount,
                     std::borrow::Cow::Owned(keeper_account_data),
                     false,
                 )
@@ -1884,21 +2892,401 @@ impl LiquidateWithMatchStrategy {
             //     "sending spot liq tx: {liquidatee:?}, asset={asset_market_index}, liability={}",
             //     liability_market_index
             // );
-            tx_sender.send_tx(
+
+            tx_sender
+                .send_tx(
+                    tx,
+                    TxIntent::LiquidateSpot {
+                        asset_market_index,
+                        liability_market_index,
+                        liquidatee,
+                        slot,
+                    },
+                    cu_limit as u64,
+                )
+                .await;
+        }
+    }
+
+    async fn try_liquidate_perp_pnl_for_deposit(
+        &self,
+        drift: &DriftClient,
+        subaccount: Pubkey,
+        liquidatee: Pubkey,
+        liability: &PositionInfo,
+        asset: &PositionInfo,
+        liq_amount: u128,
+        tx_sender: TxSender,
+        priority_fee: u64,
+        cu_limit: u32,
+        slot: u64,
+        pyth_price_update: Option<PythPriceUpdate>,
+    ) {
+        let keeper_account = match drift.try_get_account::<User>(&subaccount) {
+            Ok(data) => data,
+            Err(_) => {
+                log::warn!(target: TARGET, "keeper account not found");
+                return;
+            }
+        };
+
+        let liquidatee_account = match drift.try_get_account::<User>(&liquidatee) {
+            Ok(data) => data,
+            Err(_) => {
+                log::warn!(target: TARGET, "liquidatee account not found");
+                return;
+            }
+        };
+
+        let mut tx_builder = TransactionBuilder::new(
+            drift.program_data(),
+            subaccount,
+            std::borrow::Cow::Owned(keeper_account),
+            false,
+        )
+        .with_priority_fee(priority_fee, Some(cu_limit));
+
+        if let Some(ref update) = pyth_price_update {
+            tx_builder =
+                tx_builder.post_pyth_lazer_oracle_update(&[update.feed_id], &update.message);
+        }
+
+        tx_builder = tx_builder.liquidate_perp_pnl_for_deposit(
+            &liquidatee_account,
+            liability.market_index,
+            asset.market_index,
+            drift_rs::types::u128::from(liq_amount),
+            None,
+        );
+
+        let tx = tx_builder.build();
+
+        match tx_sender
+            .send_tx(
                 tx,
-                TxIntent::LiquidateSpot {
-                    asset_market_index,
-                    liability_market_index,
+                TxIntent::LiquidatePerpPnlForDeposit {
+                    perp_market_index: liability.market_index,
+                    spot_market_index: asset.market_index,
                     liquidatee,
                     slot,
                 },
                 cu_limit as u64,
-            );
+            )
+            .await
+        {
+            Some(sig) => {
+                self.txs_in_flight
+                    .entry(subaccount)
+                    .or_insert_with(HashSet::new)
+                    .insert(sig);
+
+                self.tx_sig_to_collateral
+                    .insert(sig, (liq_amount, current_time_millis()));
+
+                if let Some(mut free) = self.free_collateral_per_subaccount.get_mut(&subaccount) {
+                    *free = free.saturating_sub(liq_amount);
+                }
+            }
+            None => return,
+        };
+    }
+
+    /// Attempt perp pnl for deposit liquidation
+    async fn liquidate_perp_pnl_for_deposit(
+        &self,
+        drift: &DriftClient,
+        market_state: Arc<RwLock<MarketState>>,
+        subaccounts: &[Pubkey],
+        liquidatee: Pubkey,
+        liability: PositionInfo,
+        asset: PositionInfo,
+        tx_sender: TxSender,
+        priority_fee: u64,
+        cu_limit: u32,
+        slot: u64,
+        pyth_price_update: Option<PythPriceUpdate>,
+    ) {
+        let net_collateral_req = Self::calculate_net_collateral_requirement(
+            liability.collateral_required.unsigned_abs(),
+            &liability,
+            &asset,
+            Arc::clone(&market_state),
+        );
+
+        let Some(subaccount) = Self::find_best_subaccount_for_liquidation(
+            drift,
+            subaccounts,
+            false,
+            true,
+            &self.free_collateral_per_subaccount,
+            net_collateral_req.max(0) as u128,
+        ) else {
+            return;
+        };
+
+        let Some(free_collateral) = self.free_collateral_per_subaccount.get(&subaccount) else {
+            return;
+        };
+
+        let available = *free_collateral as i128;
+        let tolerance = available / 10;
+
+        let params = Self::extract_collateral_params(Arc::clone(&market_state), &liability, &asset);
+
+        let liq_amount = if net_collateral_req <= available {
+            liability.collateral_required.unsigned_abs()
+        } else {
+            Self::find_max_liq_amount(
+                liability.collateral_required.unsigned_abs(),
+                available,
+                tolerance,
+                |size| {
+                    Self::calculate_net_collateral_requirement_with_params(
+                        size, &liability, &asset, params.0, params.1, params.2, params.3, params.4,
+                        params.5, params.6, params.7,
+                    )
+                },
+            )
+        };
+
+        if liq_amount == 0 {
+            return;
         }
+
+        Self::try_liquidate_perp_pnl_for_deposit(
+            &self,
+            drift,
+            subaccount,
+            liquidatee,
+            &liability,
+            &asset,
+            liq_amount,
+            tx_sender,
+            priority_fee,
+            cu_limit,
+            slot,
+            pyth_price_update,
+        )
+        .await;
+    }
+
+    async fn try_liquidate_borrow_for_perp_pnl(
+        &self,
+        drift: &DriftClient,
+        subaccount: Pubkey,
+        liquidatee: Pubkey,
+        liability: &PositionInfo,
+        asset: &PositionInfo,
+        liq_amount: u128,
+        tx_sender: TxSender,
+        priority_fee: u64,
+        cu_limit: u32,
+        slot: u64,
+        pyth_price_update: Option<PythPriceUpdate>,
+    ) {
+        let keeper_account = match drift.try_get_account::<User>(&subaccount) {
+            Ok(data) => data,
+            Err(_) => {
+                log::warn!(target: TARGET, "keeper account not found");
+                return;
+            }
+        };
+
+        let liquidatee_account = match drift.try_get_account::<User>(&liquidatee) {
+            Ok(data) => data,
+            Err(_) => {
+                log::warn!(target: TARGET, "liquidatee account not found");
+                return;
+            }
+        };
+
+        let mut tx_builder = TransactionBuilder::new(
+            drift.program_data(),
+            subaccount,
+            std::borrow::Cow::Owned(keeper_account),
+            false,
+        )
+        .with_priority_fee(priority_fee, Some(cu_limit));
+
+        if let Some(ref update) = pyth_price_update {
+            tx_builder =
+                tx_builder.post_pyth_lazer_oracle_update(&[update.feed_id], &update.message);
+        }
+
+        tx_builder = tx_builder.liquidate_borrow_for_perp_pnl(
+            &liquidatee_account,
+            asset.market_index,
+            liability.market_index,
+            drift_rs::types::u128::from(liq_amount),
+            None,
+        );
+
+        let tx = tx_builder.build();
+
+        match tx_sender
+            .send_tx(
+                tx,
+                TxIntent::LiquidateBorrowForPerpPnl {
+                    perp_market_index: asset.market_index,
+                    spot_market_index: liability.market_index,
+                    liquidatee,
+                    slot,
+                },
+                cu_limit as u64,
+            )
+            .await
+        {
+            Some(sig) => {
+                self.txs_in_flight
+                    .entry(subaccount)
+                    .or_insert_with(HashSet::new)
+                    .insert(sig);
+
+                self.tx_sig_to_collateral
+                    .insert(sig, (liq_amount, current_time_millis()));
+
+                if let Some(mut free) = self.free_collateral_per_subaccount.get_mut(&subaccount) {
+                    *free = free.saturating_sub(liq_amount);
+                }
+            }
+            None => return,
+        };
+    }
+
+    /// Attempt borrow for perp pnl liquidation
+    async fn liquidate_borrow_for_perp_pnl(
+        &self,
+        drift: &DriftClient,
+        market_state: Arc<RwLock<MarketState>>,
+        subaccounts: &[Pubkey],
+        liquidatee: Pubkey,
+        liability: PositionInfo,
+        asset: PositionInfo,
+        tx_sender: TxSender,
+        priority_fee: u64,
+        cu_limit: u32,
+        slot: u64,
+        pyth_price_update: Option<PythPriceUpdate>,
+    ) {
+        let net_collateral_req = Self::calculate_net_collateral_requirement(
+            liability.base_amount.unsigned_abs() as u128,
+            &liability,
+            &asset,
+            Arc::clone(&market_state),
+        );
+
+        let Some(subaccount) = Self::find_best_subaccount_for_liquidation(
+            drift,
+            subaccounts,
+            true,
+            false,
+            &self.free_collateral_per_subaccount,
+            net_collateral_req.max(0) as u128,
+        ) else {
+            return;
+        };
+
+        let Some(free_collateral) = self.free_collateral_per_subaccount.get(&subaccount) else {
+            return;
+        };
+
+        let available = *free_collateral as i128;
+        let tolerance = available / 10;
+
+        let params = Self::extract_collateral_params(Arc::clone(&market_state), &liability, &asset);
+
+        let liq_amount = if net_collateral_req <= available {
+            liability.collateral_required.unsigned_abs()
+        } else {
+            Self::find_max_liq_amount(
+                liability.collateral_required.unsigned_abs(),
+                available,
+                tolerance,
+                |size| {
+                    Self::calculate_net_collateral_requirement_with_params(
+                        size, &liability, &asset, params.0, params.1, params.2, params.3, params.4,
+                        params.5, params.6, params.7,
+                    )
+                },
+            )
+        };
+
+        if liq_amount == 0 {
+            return;
+        }
+
+        Self::try_liquidate_borrow_for_perp_pnl(
+            &self,
+            drift,
+            subaccount,
+            liquidatee,
+            &liability,
+            &asset,
+            liq_amount,
+            tx_sender,
+            priority_fee,
+            cu_limit,
+            slot,
+            pyth_price_update,
+        )
+        .await;
+    }
+
+    // Settle perp pnl
+    async fn settle_perp_pnl(
+        drift: &DriftClient,
+        subaccount: Pubkey,
+        liquidatee: Pubkey,
+        market_indexes: &[u16],
+        tx_sender: TxSender,
+        priority_fee: u64,
+        cu_limit: u32,
+    ) {
+        let keeper_account = match drift.try_get_account::<User>(&subaccount) {
+            Ok(data) => data,
+            Err(_) => {
+                log::warn!(target: TARGET, "keeper account not found");
+                return;
+            }
+        };
+
+        let liquidatee_account = match drift.try_get_account::<User>(&liquidatee) {
+            Ok(data) => data,
+            Err(_) => {
+                log::warn!(target: TARGET, "liquidatee account not found");
+                return;
+            }
+        };
+
+        let mut tx_builder = TransactionBuilder::new(
+            drift.program_data(),
+            subaccount,
+            std::borrow::Cow::Owned(keeper_account),
+            false,
+        )
+        .with_priority_fee(priority_fee, Some(cu_limit));
+
+        for &market_index in market_indexes {
+            tx_builder =
+                tx_builder.settle_pnl(market_index, Some(&liquidatee), Some(&liquidatee_account));
+        }
+
+        let tx = tx_builder.build();
+
+        tx_sender
+            .send_tx(
+                tx,
+                TxIntent::SettlePnl {
+                    market_index: market_indexes[0],
+                    subaccount: liquidatee,
+                },
+                cu_limit as u64,
+            )
+            .await;
     }
 }
 
-impl LiquidationStrategy for LiquidateWithMatchStrategy {
+impl LiquidationStrategy for PrimaryLiquidationStrategy {
     fn liquidate_user<'a>(
         &'a self,
         liquidatee: Pubkey,
@@ -1910,38 +3298,137 @@ impl LiquidationStrategy for LiquidateWithMatchStrategy {
         pyth_price_update: Option<PythPriceUpdate>,
         status: UserMarginStatus,
     ) -> futures_util::future::BoxFuture<'a, ()> {
-        Self::liquidate_perp(
-            &self.drift,
-            self.dlob,
+        let perp_positions = Self::get_perp_positions_info(
             Arc::clone(&self.market_state),
-            Arc::clone(&self.metrics),
-            self.keeper_subaccount,
-            liquidatee,
-            Arc::clone(&user_account),
-            tx_sender.clone(),
-            priority_fee,
-            cu_limit,
-            slot,
-            pyth_price_update,
-            &status,
+            &user_account.perp_positions,
         );
 
-        if self.use_spot_liquidation {
-            Self::liquidate_spot(
-                self.drift.clone(),
-                Arc::clone(&self.metrics),
-                Arc::clone(&self.market_state),
-                self.keeper_subaccount,
-                liquidatee,
-                user_account,
-                tx_sender.clone(),
-                priority_fee,
-                400_000,
-                slot,
-            )
-            .boxed()
-        } else {
-            async {}.boxed()
+        let spot_positions = Self::get_spot_positions_info(
+            Arc::clone(&self.market_state),
+            &user_account.spot_positions,
+        );
+
+        let (safest_perp_tier, safest_spot_tier) =
+            Self::get_safest_tiers(&user_account, &self.drift);
+
+        let Some((liability, asset)) = Self::pick_best_asset_liability_combo(
+            Arc::clone(&self.market_state),
+            &perp_positions,
+            &spot_positions,
+            safest_perp_tier,
+            safest_spot_tier,
+        ) else {
+            log::warn!(target: TARGET, "no liquidatable positions for {:?}", liquidatee);
+            return async {}.boxed();
+        };
+
+        let has_pnl_only = perp_positions
+            .iter()
+            .any(|p| p.base_amount == 0 && p.quote_amount != 0 && p.is_asset)
+            && spot_positions.iter().filter(|s| !s.is_asset).count() == 0;
+
+        let liq_type = Self::decide_liquidation_type(&liability, asset.as_ref(), has_pnl_only);
+
+        async move {
+            match liq_type {
+                // LiquidationType::SettlePnl => {
+                //     let markets: Vec<u16> = perp_positions
+                //         .iter()
+                //         .filter(|p| p.base_amount == 0 && p.quote_amount != 0 && p.is_asset)
+                //         .map(|p| p.market_index)
+                //         .collect();
+
+                //     Self::settle_perp_pnl(
+                //         &self.drift,
+                //         self.subaccounts[0],
+                //         liquidatee,
+                //         &markets,
+                //         tx_sender,
+                //         priority_fee,
+                //         cu_limit,
+                //     )
+                //     .await;
+                // }
+                LiquidationType::PerpTakeover | LiquidationType::PerpWithFill => {
+                    Self::liquidate_perp(
+                        &self,
+                        &self.drift,
+                        self.dlob,
+                        Arc::clone(&self.market_state),
+                        Arc::clone(&self.metrics),
+                        self.subaccounts.as_slice(),
+                        liquidatee,
+                        Arc::clone(&user_account),
+                        tx_sender.clone(),
+                        priority_fee,
+                        cu_limit,
+                        slot,
+                        pyth_price_update,
+                        &status,
+                    )
+                    .await;
+                }
+                LiquidationType::SpotForSpot => {
+                    if self.use_spot_liquidation {
+                        Self::liquidate_spot(
+                            self.drift.clone(),
+                            Arc::clone(&self.metrics),
+                            Arc::clone(&self.market_state),
+                            self.subaccounts.as_slice(),
+                            liquidatee,
+                            user_account,
+                            tx_sender.clone(),
+                            priority_fee,
+                            400_000,
+                            slot,
+                        )
+                        .await;
+                    }
+                }
+                // LiquidationType::PerpPnlForDeposit => {
+                //     if let Some(asset) = asset {
+                //         Self::liquidate_perp_pnl_for_deposit(
+                //             &self,
+                //             &self.drift,
+                //             Arc::clone(&self.market_state),
+                //             self.subaccounts.as_slice(),
+                //             liquidatee,
+                //             liability,
+                //             asset,
+                //             tx_sender,
+                //             priority_fee,
+                //             cu_limit,
+                //             slot,
+                //             pyth_price_update,
+                //         )
+                //         .await;
+                //     }
+                // }
+                // LiquidationType::BorrowForPerpPnl => {
+                //     if let Some(asset) = asset {
+                //         Self::liquidate_borrow_for_perp_pnl(
+                //             &self,
+                //             &self.drift,
+                //             Arc::clone(&self.market_state),
+                //             self.subaccounts.as_slice(),
+                //             liquidatee,
+                //             liability,
+                //             asset,
+                //             tx_sender,
+                //             priority_fee,
+                //             cu_limit,
+                //             slot,
+                //             pyth_price_update,
+                //         )
+                //         .await;
+                //     }
+                // }
+                // LiquidationType::Skip => {
+                //     log::info!(target: TARGET, "skipping liquidation for {:?}: insufficient collateral", liquidatee);
+                // }
+                _ => {}
+            }
         }
+        .boxed()
     }
 }

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -1419,7 +1419,7 @@ async fn get_collateral_info_per_subaccount(
                 ) {
                     Ok(collateral_info) => {
                         collateral_info_per_subaccount.insert(subaccount_pubkey, collateral_info);
-                        log::info!(
+                        log::debug!(
                             target: TARGET,
                             "Subaccount {}: free_collateral = {}, total_collateral = {}",
                             subaccount_pubkey,

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -607,13 +607,13 @@ impl LiquidatorBot {
 
         log::info!(target: TARGET, "spawned liquidation worker");
 
-        spawn_derisk_loop(
-            drift.clone(),
-            tx_sender.clone(),
-            subaccounts,
-            Arc::clone(&priority_fee_subscriber),
-            cu_limit,
-        );
+        // spawn_derisk_loop(
+        //     drift.clone(),
+        //     tx_sender.clone(),
+        //     subaccounts,
+        //     Arc::clone(&priority_fee_subscriber),
+        //     cu_limit,
+        // );
 
         log::info!(target: TARGET, "spawned derisk worker");
 

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -768,6 +768,7 @@ impl LiquidatorBot {
                         market,
                         slot,
                     } => {
+                        log::debug!(target: TARGET, "oracle update received: market={:?}, slot={}", market, slot);
                         if slot >= current_slot {
                             if market.is_perp() {
                                 if oracle_price_data.price > 0 {
@@ -1184,6 +1185,8 @@ async fn setup_grpc(
             .and_modify(|f| f.push((*market, *source)))
             .or_insert(vec![(*market, *source)]);
     }
+
+    log::info!(target: TARGET, "oracle map has {} oracles", oracle_to_market.len());
 
     let _res = drift
         .grpc_subscribe(

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -21,13 +21,17 @@ use drift_rs::{
     grpc::{grpc_subscriber::AccountFilter, TransactionUpdate},
     jupiter::SwapMode,
     market_state::MarketStateData,
+    math::{
+        constants::{BASE_PRECISION, MARGIN_PRECISION_U128, PRICE_PRECISION, QUOTE_PRECISION},
+        liquidation::{calculate_collateral, CollateralInfo},
+    },
     priority_fee_subscriber::PriorityFeeSubscriber,
     titan,
     types::{
         accounts::{PerpMarket, SpotMarket, User},
         MarginRequirementType, MarketId, MarketStatus, MarketType, OracleSource, SpotBalanceType,
     },
-    DriftClient, GrpcSubscribeOpts, MarketState, Pubkey, TransactionBuilder,
+    DriftClient, GrpcSubscribeOpts, MarketState, Pubkey, TransactionBuilder, Wallet,
 };
 use drift_rs::{jupiter::JupiterSwapApi, titan::TitanSwapApi};
 use solana_sdk::{account::Account, clock::Slot, compute_budget::ComputeBudgetInstruction};
@@ -350,6 +354,7 @@ pub trait LiquidationStrategy {
         cu_limit: u32,
         slot: u64,
         pyth_price_update: Option<PythPriceUpdate>,
+        collateral_info_per_subaccount: Arc<RwLock<HashMap<Pubkey, CollateralInfo>>>,
         status: UserMarginStatus,
     ) -> futures_util::future::BoxFuture<'a, ()>;
 }
@@ -395,6 +400,8 @@ pub struct LiquidatorBot {
     pyth_price_feed: Option<tokio::sync::mpsc::Receiver<PythPriceUpdate>>,
     /// Dashboard state for HTTP API
     dashboard_state: DashboardStateRef,
+    /// Track collateral info per subaccount
+    collateral_info_per_subaccount: Arc<RwLock<HashMap<Pubkey, CollateralInfo>>>,
 }
 
 impl LiquidatorBot {
@@ -506,6 +513,10 @@ impl LiquidatorBot {
 
         log::info!(target: TARGET, "subscribed pyth price feeds");
 
+        let collateral_info_per_subaccount = Arc::new(RwLock::new(
+            get_collateral_info_per_subaccount(&drift, &config.get_subaccounts()).await,
+        ));
+
         // start liquidation worker
         let (liq_tx, liq_rx) = tokio::sync::mpsc::channel::<(
             Pubkey,
@@ -532,6 +543,7 @@ impl LiquidatorBot {
                 .and_then(|s| s.parse::<u32>().ok())
                 .unwrap_or(config.fill_cu_limit),
             Arc::clone(&priority_fee_subscriber),
+            Arc::clone(&collateral_info_per_subaccount),
         );
 
         log::info!(target: TARGET, "spawned liquidation worker");
@@ -545,6 +557,7 @@ impl LiquidatorBot {
             liq_tx,
             pyth_price_feed: Some(pyth_price_feed),
             dashboard_state,
+            collateral_info_per_subaccount,
         }
     }
 
@@ -685,6 +698,12 @@ impl LiquidatorBot {
                         user,
                         slot: update_slot,
                     } => {
+                        // Update collaterals
+                        let new_collateral =
+                            get_collateral_info_per_subaccount(&drift, &config.get_subaccounts())
+                                .await;
+                        *self.collateral_info_per_subaccount.write().unwrap() = new_collateral;
+
                         let old_user = users.get(&pubkey).map(|m| &m.user);
                         dlob_notifier.user_update(pubkey, old_user, &user, update_slot);
                         let now_ms = current_time_millis();
@@ -1135,6 +1154,82 @@ impl LiquidatorBot {
     }
 }
 
+async fn get_collateral_info_per_subaccount(
+    drift: &DriftClient,
+    subaccounts: &[u16],
+) -> HashMap<Pubkey, CollateralInfo> {
+    let mut collateral_info_per_subaccount = HashMap::<Pubkey, CollateralInfo>::new();
+    for subaccount in subaccounts {
+        let subaccount_pubkey = Wallet::derive_user_account(&drift.wallet.authority(), *subaccount);
+        match drift.get_user_account(&subaccount_pubkey).await {
+            Ok(user_account) => {
+                match calculate_collateral(
+                    &drift,
+                    &user_account,
+                    MarginRequirementType::Maintenance,
+                ) {
+                    Ok(collateral_info) => {
+                        collateral_info_per_subaccount.insert(subaccount_pubkey, collateral_info);
+                        log::info!(
+                            target: TARGET,
+                            "Subaccount {}: free_collateral = {}, total_collateral = {}",
+                            subaccount,
+                            collateral_info.free,
+                            collateral_info.total
+                        );
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            target: TARGET,
+                            "Failed to calculate collateral for subaccount {}: {:?}",
+                            subaccount,
+                            e
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                log::warn!(
+                    target: TARGET,
+                    "Failed to load subaccount {}: {:?}",
+                    subaccount,
+                    e
+                );
+            }
+        }
+    }
+    collateral_info_per_subaccount
+}
+
+fn calculate_perp_collateral_requirement(
+    market_state: &MarketState,
+    market_index: u16,
+    base_asset_amount: i64,
+) -> Option<u128> {
+    let state = market_state.load();
+
+    let perp_market = state.perp_markets.get(&market_index)?;
+    let oracle = state.perp_oracle_prices.get(&market_index)?;
+
+    let margin_ratio = perp_market
+        .get_margin_ratio(
+            base_asset_amount.unsigned_abs() as u128,
+            MarginRequirementType::Initial,
+            false,
+        )
+        .ok()?;
+
+    let collateral = (base_asset_amount.abs() as u128)
+        .saturating_mul(oracle.price as u128)
+        .saturating_mul(QUOTE_PRECISION)
+        .saturating_mul(margin_ratio as u128)
+        .saturating_div(MARGIN_PRECISION_U128)
+        .saturating_div(PRICE_PRECISION)
+        .saturating_div(BASE_PRECISION);
+
+    Some(collateral)
+}
+
 fn on_transaction_update_fn(
     tx_sender: TxSender,
 ) -> impl Fn(&TransactionUpdate) + Send + Sync + 'static {
@@ -1359,6 +1454,72 @@ fn try_liquidate_with_match(
     );
 }
 
+/// Try to liquidate by taking over position
+fn try_liquidate_with_collateral(
+    drift: &DriftClient,
+    market_index: u16,
+    keeper_subaccount: Pubkey,
+    liquidatee_subaccount: Pubkey,
+    base_asset_amount: u64,
+    tx_sender: TxSender,
+    priority_fee: u64,
+    cu_limit: u32,
+    slot: u64,
+    pyth_price_update: Option<PythPriceUpdate>,
+) {
+    let keeper_account_data = drift.try_get_account::<User>(&keeper_subaccount);
+    if keeper_account_data.is_err() {
+        log::debug!(target: TARGET, "keeper acc lookup failed={keeper_subaccount:?}");
+        return;
+    }
+    let liquidatee_subaccount_data = drift.try_get_account::<User>(&liquidatee_subaccount);
+    if liquidatee_subaccount_data.is_err() {
+        log::debug!(target: TARGET, "liquidatee acc lookup failed={liquidatee_subaccount:?}");
+        return;
+    }
+
+    let mut tx_builder = TransactionBuilder::new(
+        drift.program_data(),
+        keeper_subaccount,
+        std::borrow::Cow::Owned(keeper_account_data.unwrap()),
+        false,
+    )
+    .with_priority_fee(priority_fee, Some(cu_limit));
+
+    if let Some(ref update) = pyth_price_update {
+        tx_builder = tx_builder.post_pyth_lazer_oracle_update(&[update.feed_id], &update.message);
+    }
+
+    tx_builder = tx_builder.liquidate_perp(
+        market_index,
+        &liquidatee_subaccount_data.unwrap(),
+        base_asset_amount,
+        None,
+    );
+
+    // large accounts list, bump CU limit to compensate
+    if let Some(ix) = tx_builder.ixs().last() {
+        if ix.accounts.len() >= 20 {
+            tx_builder = tx_builder.set_ix(
+                1,
+                ComputeBudgetInstruction::set_compute_unit_limit(cu_limit * 2),
+            );
+        }
+    }
+
+    let tx = tx_builder.build();
+
+    tx_sender.send_tx(
+        tx,
+        TxIntent::LiquidatePerp {
+            market_index,
+            liquidatee: liquidatee_subaccount,
+            slot,
+        },
+        cu_limit as u64,
+    );
+}
+
 fn spawn_liquidation_worker(
     tx_sender: TxSender,
     strategy: Arc<dyn LiquidationStrategy + Send + Sync>,
@@ -1372,6 +1533,7 @@ fn spawn_liquidation_worker(
     )>,
     cu_limit: u32,
     priority_fee_subscriber: Arc<PriorityFeeSubscriber>,
+    collateral_info_per_subaccount: Arc<RwLock<HashMap<Pubkey, CollateralInfo>>>,
 ) {
     let mut rate_limit = HashMap::<Pubkey, u64>::new();
 
@@ -1406,6 +1568,7 @@ fn spawn_liquidation_worker(
             let liquidatee_clone = liquidatee;
             let user_account_clone = Arc::new(user_account);
             let tx_sender_clone = tx_sender.clone();
+            let collateral_info_clone = Arc::clone(&collateral_info_per_subaccount);
 
             tokio::spawn(async move {
                 let deadline = std::time::Duration::from_millis(LIQUIDATION_DEADLINE_MS);
@@ -1420,6 +1583,7 @@ fn spawn_liquidation_worker(
                         cu_limit,
                         slot,
                         pyth_price_update,
+                        collateral_info_clone,
                         status,
                     ),
                 )
@@ -1539,6 +1703,7 @@ impl LiquidateWithMatchStrategy {
         cu_limit: u32,
         slot: u64,
         pyth_price_update: Option<PythPriceUpdate>,
+        collateral_info_per_subaccount: Arc<RwLock<HashMap<Pubkey, CollateralInfo>>>,
         status: &UserMarginStatus,
     ) {
         // Check isolated liquidations first
@@ -1613,6 +1778,33 @@ impl LiquidateWithMatchStrategy {
             return;
         };
 
+        // Calculate collateral required
+        let Some(collateral_required) = calculate_perp_collateral_requirement(
+            market_state,
+            pos.market_index,
+            pos.base_asset_amount,
+        ) else {
+            log::warn!(target: TARGET, "failed to calculate collateral requirement for market {}", pos.market_index);
+            return;
+        };
+
+        // Check if we have enough collateral
+        let collateral_map = collateral_info_per_subaccount.read().unwrap();
+        let Some(collateral_info) = collateral_map.get(&keeper_subaccount) else {
+            log::warn!(target: TARGET, "no collateral info for keeper subaccount");
+            return;
+        };
+
+        if collateral_info.free < collateral_required as i128 {
+            log::info!(
+                target: TARGET,
+                "insufficient collateral: need {}, have {}",
+                collateral_required,
+                collateral_info.free
+            );
+            return;
+        }
+
         metrics
             .liquidation_attempts
             .with_label_values(&["perp"])
@@ -1641,12 +1833,25 @@ impl LiquidateWithMatchStrategy {
 
         let pyth_update = pyth_price_update.filter(|update| update.price != oracle_price);
 
-        try_liquidate_with_match(
+        // try_liquidate_with_match(
+        //     &drift,
+        //     pos.market_index,
+        //     keeper_subaccount,
+        //     liquidatee,
+        //     makers.as_slice(),
+        //     tx_sender,
+        //     priority_fee,
+        //     cu_limit,
+        //     slot,
+        //     pyth_update,
+        // );
+
+        try_liquidate_with_collateral(
             &drift,
             pos.market_index,
             keeper_subaccount,
             liquidatee,
-            makers.as_slice(),
+            pos.base_asset_amount.unsigned_abs(),
             tx_sender,
             priority_fee,
             cu_limit,
@@ -1896,6 +2101,7 @@ impl LiquidationStrategy for LiquidateWithMatchStrategy {
         cu_limit: u32,
         slot: u64,
         pyth_price_update: Option<PythPriceUpdate>,
+        collateral_info_per_subaccount: Arc<RwLock<HashMap<Pubkey, CollateralInfo>>>,
         status: UserMarginStatus,
     ) -> futures_util::future::BoxFuture<'a, ()> {
         Self::liquidate_perp(
@@ -1911,6 +2117,7 @@ impl LiquidationStrategy for LiquidateWithMatchStrategy {
             cu_limit,
             slot,
             pyth_price_update,
+            collateral_info_per_subaccount,
             &status,
         );
 

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -10,7 +10,7 @@ use anchor_lang::Discriminator;
 use futures_util::FutureExt;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    sync::Arc,
+    sync::{Arc, RwLock},
     time::{SystemTime, UNIX_EPOCH},
 };
 use tokio::sync::mpsc::error::TryRecvError;
@@ -380,7 +380,7 @@ pub struct LiquidatorBot {
     dlob_notifier: DLOBNotifier,
     config: Config,
     /// stores drift perp+spot market metadata and oracle prices
-    market_state: &'static MarketState,
+    market_state: Arc<RwLock<MarketState>>,
     /// receives new updates from grpc
     events_rx: tokio::sync::mpsc::Receiver<GrpcEvent>,
     /// sends liquidatable accounts to work thread (pubkey, user, slot, timestamp_ms, pyth price)
@@ -488,8 +488,8 @@ impl LiquidatorBot {
                 market_state.set_spot_oracle_price(market.market_index, oracle.data);
             }
         }
-        let market_state: &'static MarketState =
-            Box::leak(Box::new(MarketState::new(market_state)));
+
+        let market_state = Arc::new(RwLock::new(MarketState::new(market_state)));
 
         let pyth_access_token = std::env::var("PYTH_LAZER_TOKEN").expect("pyth access token");
         let pyth_feed_cli = pyth_lazer_client::LazerClient::new(
@@ -521,7 +521,7 @@ impl LiquidatorBot {
             Arc::new(LiquidateWithMatchStrategy {
                 dlob,
                 drift: drift.clone(),
-                market_state,
+                market_state: Arc::clone(&market_state),
                 keeper_subaccount,
                 metrics: Arc::clone(&metrics),
                 use_spot_liquidation: config.use_spot_liquidation,
@@ -576,11 +576,15 @@ impl LiquidatorBot {
             .backend()
             .account_map()
             .iter_accounts_with::<User>(|pubkey, user, _slot| {
-                let margin_info = match self.market_state.calculate_simplified_margin_requirement(
-                    user,
-                    MarginRequirementType::Maintenance,
-                    Some(liquidation_margin_buffer_ratio),
-                ) {
+                let margin_info = match self
+                    .market_state
+                    .read()
+                    .unwrap()
+                    .calculate_simplified_margin_requirement(
+                        user,
+                        MarginRequirementType::Maintenance,
+                        Some(liquidation_margin_buffer_ratio),
+                    ) {
                     Ok(info) => info,
                     Err(e) => {
                         std::mem::forget(e);
@@ -649,6 +653,8 @@ impl LiquidatorBot {
                                 // Update market state with perp pyth price for margin calculation
                                 if price > 0 {
                                     self.market_state
+                                        .write()
+                                        .unwrap()
                                         .set_perp_pyth_price(market_id, price as i64);
                                 }
                             }
@@ -656,6 +662,8 @@ impl LiquidatorBot {
                                 // Update market state with spot pyth price for margin calculation
                                 if price > 0 {
                                     self.market_state
+                                        .write()
+                                        .unwrap()
                                         .set_spot_pyth_price(market_id, price as i64);
                                 }
                             }
@@ -721,6 +729,8 @@ impl LiquidatorBot {
                             // calculate user margin after update
                             let margin_info = match self
                                 .market_state
+                                .read()
+                                .unwrap()
                                 .calculate_simplified_margin_requirement(
                                     &user,
                                     MarginRequirementType::Maintenance,
@@ -762,11 +772,15 @@ impl LiquidatorBot {
                             if market.is_perp() {
                                 if oracle_price_data.price > 0 {
                                     self.market_state
+                                        .write()
+                                        .unwrap()
                                         .set_perp_oracle_price(market.index(), oracle_price_data);
                                 }
                             } else {
                                 if oracle_price_data.price > 0 {
                                     self.market_state
+                                        .write()
+                                        .unwrap()
                                         .set_spot_oracle_price(market.index(), oracle_price_data);
                                 }
                             }
@@ -785,13 +799,13 @@ impl LiquidatorBot {
                     }
                     GrpcEvent::PerpMarketUpdate { market, slot } => {
                         if slot >= current_slot {
-                            self.market_state.set_perp_market(market);
+                            self.market_state.write().unwrap().set_perp_market(market);
                             current_slot = slot;
                         }
                     }
                     GrpcEvent::SpotMarketUpdate { market, slot } => {
                         if slot >= current_slot {
-                            self.market_state.set_spot_market(market);
+                            self.market_state.write().unwrap().set_spot_market(market);
                             current_slot = slot;
                         }
                     }
@@ -851,6 +865,8 @@ impl LiquidatorBot {
 
                         let margin_info = match self
                             .market_state
+                            .read()
+                            .unwrap()
                             .calculate_simplified_margin_requirement(
                                 &user_meta.user,
                                 MarginRequirementType::Maintenance,
@@ -954,18 +970,21 @@ impl LiquidatorBot {
                             }
                         }
 
-                        let margin_info =
-                            match self.market_state.calculate_simplified_margin_requirement(
+                        let margin_info = match self
+                            .market_state
+                            .read()
+                            .unwrap()
+                            .calculate_simplified_margin_requirement(
                                 &user_meta.user,
                                 MarginRequirementType::Maintenance,
                                 Some(liquidation_margin_buffer_ratio),
                             ) {
-                                Ok(info) => info,
-                                Err(e) => {
-                                    std::mem::forget(e);
-                                    return false;
-                                }
-                            };
+                            Ok(info) => info,
+                            Err(e) => {
+                                std::mem::forget(e);
+                                return false;
+                            }
+                        };
 
                         check_margin_status(&margin_info).is_at_risk()
                     } else {
@@ -1033,19 +1052,22 @@ impl LiquidatorBot {
                         }
                     }
 
-                    let margin_info =
-                        match self.market_state.calculate_simplified_margin_requirement(
+                    let margin_info = match self
+                        .market_state
+                        .read()
+                        .unwrap()
+                        .calculate_simplified_margin_requirement(
                             &user_meta.user,
                             MarginRequirementType::Maintenance,
                             Some(liquidation_margin_buffer_ratio),
                         ) {
-                            Ok(info) => info,
-                            Err(e) => {
-                                std::mem::forget(e);
-                                log::warn!(target: TARGET, "margin calc failed for {:?}", pubkey);
-                                continue;
-                            }
-                        };
+                        Ok(info) => info,
+                        Err(e) => {
+                            std::mem::forget(e);
+                            log::warn!(target: TARGET, "margin calc failed for {:?}", pubkey);
+                            continue;
+                        }
+                    };
 
                     let status = check_margin_status(&margin_info);
 
@@ -1443,7 +1465,7 @@ fn spawn_liquidation_worker(
 pub struct LiquidateWithMatchStrategy {
     pub drift: DriftClient,
     pub dlob: &'static DLOB,
-    pub market_state: &'static MarketState,
+    pub market_state: Arc<RwLock<MarketState>>,
     pub keeper_subaccount: Pubkey,
     pub metrics: Arc<Metrics>,
     pub use_spot_liquidation: bool,
@@ -1454,15 +1476,18 @@ impl LiquidateWithMatchStrategy {
     fn find_top_makers(
         drift: &DriftClient,
         dlob: &'static DLOB,
-        market_state: &'static MarketState,
+        market_state: Arc<RwLock<MarketState>>,
         market_index: u16,
         base_asset_amount: i64,
     ) -> Option<Vec<User>> {
         let l3_book = dlob.get_l3_snapshot_safe(market_index, MarketType::Perp)?;
 
-        let oracle_price = match market_state.get_perp_oracle_price(market_index) {
-            Some(data) if data.price > 0 => data.price as u64,
-            _ => return None,
+        let oracle_price = {
+            let state = market_state.read().unwrap();
+            match state.get_perp_oracle_price(market_index) {
+                Some(data) if data.price > 0 => data.price as u64,
+                _ => return None,
+            }
         };
 
         let maker_pubkeys: Vec<Pubkey> = if base_asset_amount >= 0 {
@@ -1504,7 +1529,7 @@ impl LiquidateWithMatchStrategy {
     fn liquidate_perp(
         drift: &DriftClient,
         dlob: &'static DLOB,
-        market_state: &'static MarketState,
+        market_state: Arc<RwLock<MarketState>>,
         metrics: Arc<Metrics>,
         keeper_subaccount: Pubkey,
         liquidatee: Pubkey,
@@ -1538,17 +1563,23 @@ impl LiquidateWithMatchStrategy {
                     let Some(makers) = Self::find_top_makers(
                         drift,
                         dlob,
-                        market_state,
+                        Arc::clone(&market_state),
                         *market_index,
                         pos.base_asset_amount,
                     ) else {
                         return;
                     };
 
-                    let oracle_price = market_state
-                        .get_perp_oracle_price(*market_index)
-                        .map(|x| x.price)
-                        .unwrap_or(0) as u64;
+                    let oracle_price = {
+                        let state = market_state.read().unwrap();
+                        match state.get_perp_oracle_price(pos.market_index) {
+                            Some(data) if data.price > 0 => data.price as u64,
+                            _ => {
+                                log::warn!(target: TARGET, "invalid oracle price for market {}", pos.market_index);
+                                return;
+                            }
+                        }
+                    };
 
                     let pyth_update =
                         pyth_price_update.filter(|update| update.price != oracle_price);
@@ -1592,17 +1623,23 @@ impl LiquidateWithMatchStrategy {
         let Some(makers) = Self::find_top_makers(
             drift,
             dlob,
-            market_state,
+            Arc::clone(&market_state),
             pos.market_index,
             pos.base_asset_amount,
         ) else {
             return;
         };
 
-        let oracle_price = market_state
-            .get_perp_oracle_price(pos.market_index)
-            .map(|x| x.price)
-            .unwrap_or(0) as u64;
+        let oracle_price = {
+            let state = market_state.read().unwrap();
+            match state.get_perp_oracle_price(pos.market_index) {
+                Some(data) if data.price > 0 => data.price as u64,
+                _ => {
+                    log::warn!(target: TARGET, "invalid oracle price for market {}", pos.market_index);
+                    return;
+                }
+            }
+        };
 
         let pyth_update = pyth_price_update.filter(|update| update.price != oracle_price);
 
@@ -1624,7 +1661,7 @@ impl LiquidateWithMatchStrategy {
     async fn liquidate_spot(
         drift: DriftClient,
         metrics: Arc<Metrics>,
-        market_state: Arc<MarketStateData>,
+        market_state: Arc<RwLock<MarketState>>,
         keeper_subaccount: Pubkey,
         liquidatee: Pubkey,
         user_account: Arc<User>,
@@ -1640,11 +1677,16 @@ impl LiquidateWithMatchStrategy {
             .iter()
             .filter(|p| matches!(p.balance_type, SpotBalanceType::Borrow) && !p.is_available())
         {
-            let Some(spot_market) = market_state.spot_markets.get(&pos.market_index) else {
-                continue;
+            let spot_market = {
+                let state = market_state.read().unwrap();
+                let state_data = state.load();
+                match state_data.spot_markets.get(&pos.market_index) {
+                    Some(m) => *m,
+                    None => continue,
+                }
             };
 
-            let token_amount = match pos.get_token_amount(spot_market) {
+            let token_amount = match pos.get_token_amount(&spot_market) {
                 Ok(amount) => amount as u64,
                 Err(_) => continue,
             };
@@ -1861,7 +1903,7 @@ impl LiquidationStrategy for LiquidateWithMatchStrategy {
         Self::liquidate_perp(
             &self.drift,
             self.dlob,
-            self.market_state,
+            Arc::clone(&self.market_state),
             Arc::clone(&self.metrics),
             self.keeper_subaccount,
             liquidatee,
@@ -1878,7 +1920,7 @@ impl LiquidationStrategy for LiquidateWithMatchStrategy {
             Self::liquidate_spot(
                 self.drift.clone(),
                 Arc::clone(&self.metrics),
-                self.market_state.load(),
+                Arc::clone(&self.market_state),
                 self.keeper_subaccount,
                 liquidatee,
                 user_account,

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -37,7 +37,7 @@ use drift_rs::{
         MarginRequirementType, MarketId, MarketStatus, MarketType, OracleSource, OrderParams,
         OrderType, PerpPosition, PositionDirection, SpotBalanceType, SpotPosition,
     },
-    DriftClient, GrpcSubscribeOpts, MarketState, Pubkey, TransactionBuilder, Wallet,
+    DriftClient, GrpcSubscribeOpts, MarketState, Pubkey, TransactionBuilder,
 };
 use drift_rs::{jupiter::JupiterSwapApi, titan::TitanSwapApi};
 use solana_sdk::{
@@ -412,7 +412,8 @@ pub struct LiquidatorBot {
     collateral_info_per_subaccount: Arc<DashMap<Pubkey, CollateralInfo>>,
     /// In flight txs tracking
     txs_in_flight: Arc<DashMap<Pubkey, HashSet<Signature>>>,
-    tx_sig_to_collateral: Arc<DashMap<Signature, u128>>,
+    // Map(Signature,(collateral, ts))
+    tx_sig_to_collateral: Arc<DashMap<Signature, (u128, u64)>>,
     free_collateral_per_subaccount: Arc<DashMap<Pubkey, u128>>,
 }
 
@@ -497,7 +498,7 @@ impl LiquidatorBot {
             (Arc::new(txs), Arc::new(free))
         };
 
-        let tx_sig_to_collateral = Arc::new(DashMap::new());
+        let tx_sig_to_collateral: Arc<DashMap<Signature, (u128, u64)>> = Arc::new(DashMap::new());
 
         let tx_worker = TxWorker::new(
             drift.clone(),
@@ -607,6 +608,22 @@ impl LiquidatorBot {
         );
 
         log::info!(target: TARGET, "spawned derisk worker");
+
+        let tx_sig_to_collateral_clone = Arc::clone(&tx_sig_to_collateral);
+        let txs_in_flight_clone = Arc::clone(&txs_in_flight);
+
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(30));
+            loop {
+                interval.tick().await;
+                clean_stale_in_flight_txs(
+                    Arc::clone(&tx_sig_to_collateral_clone),
+                    Arc::clone(&txs_in_flight_clone),
+                );
+            }
+        });
+
+        log::info!(target: TARGET, "spawned stale in flight txs cleanup worker");
 
         LiquidatorBot {
             drift,
@@ -783,7 +800,7 @@ impl LiquidatorBot {
                             if let Some(in_flight) = self.txs_in_flight.get(subaccount_pubkey) {
                                 for sig in in_flight.value().iter() {
                                     if let Some(reserved) = self.tx_sig_to_collateral.get(sig) {
-                                        free = free.saturating_sub(*reserved.value() as i128);
+                                        free = free.saturating_sub(reserved.value().0 as i128);
                                     }
                                 }
                             }
@@ -1241,6 +1258,24 @@ impl LiquidatorBot {
     }
 }
 
+fn clean_stale_in_flight_txs(
+    tx_sig_to_collateral: Arc<DashMap<Signature, (u128, u64)>>,
+    txs_in_flight: Arc<DashMap<Pubkey, HashSet<Signature>>>,
+) {
+    let now = current_time_millis();
+    let timeout_ms = 60_000;
+
+    tx_sig_to_collateral.retain(|sig, (_, ts)| {
+        let is_stale = now.saturating_sub(*ts) > timeout_ms;
+        if is_stale {
+            for mut entry in txs_in_flight.iter_mut() {
+                entry.value_mut().remove(sig);
+            }
+        }
+        !is_stale
+    });
+}
+
 async fn derisk_subaccount(
     drift: &DriftClient,
     tx_sender: &TxSender,
@@ -1662,7 +1697,8 @@ pub struct PrimaryLiquidationStrategy {
     pub metrics: Arc<Metrics>,
     pub use_spot_liquidation: bool,
     pub txs_in_flight: Arc<DashMap<Pubkey, HashSet<Signature>>>,
-    pub tx_sig_to_collateral: Arc<DashMap<Signature, u128>>,
+    // Map(Signature,(collateral, ts))
+    pub tx_sig_to_collateral: Arc<DashMap<Signature, (u128, u64)>>,
     pub free_collateral_per_subaccount: Arc<DashMap<Pubkey, u128>>,
 }
 
@@ -2370,7 +2406,7 @@ impl PrimaryLiquidationStrategy {
                     .insert(sig);
 
                 self.tx_sig_to_collateral
-                    .insert(sig, base_asset_amount as u128);
+                    .insert(sig, (base_asset_amount as u128, current_time_millis()));
 
                 if let Some(mut free) = self.free_collateral_per_subaccount.get_mut(&subaccount) {
                     *free = free.saturating_sub(base_asset_amount as u128);
@@ -2899,7 +2935,8 @@ impl PrimaryLiquidationStrategy {
                     .or_insert_with(HashSet::new)
                     .insert(sig);
 
-                self.tx_sig_to_collateral.insert(sig, liq_amount);
+                self.tx_sig_to_collateral
+                    .insert(sig, (liq_amount, current_time_millis()));
 
                 if let Some(mut free) = self.free_collateral_per_subaccount.get_mut(&subaccount) {
                     *free = free.saturating_sub(liq_amount);
@@ -3060,7 +3097,8 @@ impl PrimaryLiquidationStrategy {
                     .or_insert_with(HashSet::new)
                     .insert(sig);
 
-                self.tx_sig_to_collateral.insert(sig, liq_amount);
+                self.tx_sig_to_collateral
+                    .insert(sig, (liq_amount, current_time_millis()));
 
                 if let Some(mut free) = self.free_collateral_per_subaccount.get_mut(&subaccount) {
                     *free = free.saturating_sub(liq_amount);

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -1873,7 +1873,7 @@ impl PrimaryLiquidationStrategy {
         collateral_required: u128,
         has_makers: bool,
     ) -> LiquidationType {
-        const POSITION_AMOUNT_THRESHOLD: u64 = 1_000 * BASE_PRECISION_U64;
+        const POSITION_AMOUNT_THRESHOLD: u64 = 5_000 * BASE_PRECISION_U64;
 
         let is_small_position = quote_asset_amount <= POSITION_AMOUNT_THRESHOLD;
         let can_afford_takeover = collateral_available >= collateral_required as i128;

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -647,13 +647,17 @@ impl LiquidatorBot {
                             MarketType::Perp => {
                                 pyth_perp_prices.insert(market_id, update);
                                 // Update market state with perp pyth price for margin calculation
-                                self.market_state
-                                    .set_perp_pyth_price(market_id, price as i64);
+                                if price > 0 {
+                                    self.market_state
+                                        .set_perp_pyth_price(market_id, price as i64);
+                                }
                             }
                             MarketType::Spot => {
                                 // Update market state with spot pyth price for margin calculation
-                                self.market_state
-                                    .set_spot_pyth_price(market_id, price as i64);
+                                if price > 0 {
+                                    self.market_state
+                                        .set_spot_pyth_price(market_id, price as i64);
+                                }
                             }
                         }
                     }
@@ -756,11 +760,15 @@ impl LiquidatorBot {
                     } => {
                         if slot >= current_slot {
                             if market.is_perp() {
-                                self.market_state
-                                    .set_perp_oracle_price(market.index(), oracle_price_data);
+                                if oracle_price_data.price > 0 {
+                                    self.market_state
+                                        .set_perp_oracle_price(market.index(), oracle_price_data);
+                                }
                             } else {
-                                self.market_state
-                                    .set_spot_oracle_price(market.index(), oracle_price_data);
+                                if oracle_price_data.price > 0 {
+                                    self.market_state
+                                        .set_spot_oracle_price(market.index(), oracle_price_data);
+                                }
                             }
                             let now_ms = current_time_millis();
                             oracle_prices.insert(

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -9,6 +9,7 @@
 use anchor_lang::Discriminator;
 use futures_util::FutureExt;
 use std::{
+    cmp::Reverse,
     collections::{BTreeMap, HashMap, HashSet},
     sync::{Arc, RwLock},
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -17,14 +18,14 @@ use tokio::sync::mpsc::error::TryRecvError;
 
 use drift_rs::{
     dlob::{DLOBNotifier, DLOB},
-    ffi::{OraclePriceData, SimplifiedMarginCalculation},
+    ffi::{spot_position_get_signed_token_amount, OraclePriceData, SimplifiedMarginCalculation},
     grpc::{grpc_subscriber::AccountFilter, TransactionUpdate},
     jupiter::SwapMode,
     market_state::MarketStateData,
     math::{
         constants::{
             BASE_PRECISION, BASE_PRECISION_U64, MARGIN_PRECISION_U128, PRICE_PRECISION,
-            QUOTE_PRECISION,
+            QUOTE_PRECISION, SPOT_WEIGHT_PRECISION, SPOT_WEIGHT_PRECISION_U128,
         },
         liquidation::{calculate_collateral, CollateralInfo},
     },
@@ -33,7 +34,7 @@ use drift_rs::{
     types::{
         accounts::{PerpMarket, SpotMarket, User},
         MarginRequirementType, MarketId, MarketStatus, MarketType, OracleSource, OrderParams,
-        OrderType, PositionDirection, SpotBalanceType,
+        OrderType, PerpPosition, PositionDirection, SpotBalanceType, SpotPosition,
     },
     DriftClient, GrpcSubscribeOpts, MarketState, Pubkey, TransactionBuilder, Wallet,
 };
@@ -1615,6 +1616,66 @@ fn try_liquidate_with_collateral(
     );
 }
 
+fn try_liquidate_perp_pnl_for_deposit(
+    drift: &DriftClient,
+    keeper_subaccount: Pubkey,
+    liquidatee: Pubkey,
+    liability: &PositionInfo,
+    asset: &PositionInfo,
+    tx_sender: TxSender,
+    priority_fee: u64,
+    cu_limit: u32,
+    slot: u64,
+    pyth_price_update: Option<PythPriceUpdate>,
+) {
+    let keeper_account = match drift.try_get_account::<User>(&keeper_subaccount) {
+        Ok(data) => data,
+        Err(_) => {
+            log::warn!(target: TARGET, "keeper account not found");
+            return;
+        }
+    };
+
+    let liquidatee_account = match drift.try_get_account::<User>(&liquidatee) {
+        Ok(data) => data,
+        Err(_) => {
+            log::warn!(target: TARGET, "liquidatee account not found");
+            return;
+        }
+    };
+
+    let mut tx_builder = TransactionBuilder::new(
+        drift.program_data(),
+        keeper_subaccount,
+        std::borrow::Cow::Owned(keeper_account),
+        false,
+    )
+    .with_priority_fee(priority_fee, Some(cu_limit));
+
+    if let Some(ref update) = pyth_price_update {
+        tx_builder = tx_builder.post_pyth_lazer_oracle_update(&[update.feed_id], &update.message);
+    }
+
+    // tx_builder = tx_builder.liquidate_perp_pnl_for_deposit(
+    //     liability.market_index,
+    //     asset.market_index,
+    //     &liquidatee_account,
+    // );
+
+    // let tx = tx_builder.build();
+
+    // tx_sender.send_tx(
+    //     tx,
+    //     TxIntent::LiquidatePerpPnlForDeposit {
+    //         perp_market_index: liability.market_index,
+    //         spot_market_index: asset.market_index,
+    //         liquidatee,
+    //         slot,
+    //     },
+    //     cu_limit as u64,
+    // );
+}
+
 fn spawn_liquidation_worker(
     tx_sender: TxSender,
     strategy: Arc<dyn LiquidationStrategy + Send + Sync>,
@@ -1719,11 +1780,25 @@ fn spawn_liquidation_worker(
     });
 }
 
-enum PerpLiquidationMethod {
-    WithFill,
-    Takeover,
+enum LiquidationType {
+    PerpWithFill,
+    PerpTakeover,
+    PerpPnlForDeposit,
+    BorrowForPerpPnl,
+    SpotForSpot,
     Skip,
 }
+
+#[derive(Debug, Clone)]
+struct PositionInfo {
+    market_type: MarketType,
+    market_index: u16,
+    is_asset: bool,
+    collateral_required: i128,
+    base_amount: i64,
+    quote_amount: i64,
+}
+
 /// Primary liquidation strategy: Prefers takeover for large positions, uses maker matching for rest
 pub struct PrimaryLiquidationStrategy {
     pub drift: DriftClient,
@@ -1742,21 +1817,156 @@ impl PrimaryLiquidationStrategy {
         collateral_available: i128,
         collateral_required: u128,
         has_makers: bool,
-    ) -> PerpLiquidationMethod {
+    ) -> LiquidationType {
         const LARGE_POSITION_THRESHOLD: u64 = 10_000 * BASE_PRECISION_U64;
 
         let is_large_position = base_asset_amount_to_liquidate >= LARGE_POSITION_THRESHOLD;
         let can_afford_takeover = collateral_available >= collateral_required as i128;
 
         if is_large_position && can_afford_takeover {
-            PerpLiquidationMethod::Takeover
+            LiquidationType::PerpTakeover
         } else if has_makers {
-            PerpLiquidationMethod::WithFill
+            LiquidationType::PerpWithFill
         } else if can_afford_takeover {
-            PerpLiquidationMethod::Takeover
+            LiquidationType::PerpTakeover
         } else {
-            PerpLiquidationMethod::Skip
+            LiquidationType::Skip
         }
+    }
+
+    fn decide_liquidation_type(
+        liability: &PositionInfo,
+        asset: Option<&PositionInfo>,
+    ) -> LiquidationType {
+        match (liability.market_type, asset.map(|a| a.market_type)) {
+            (MarketType::Perp, None) => LiquidationType::PerpTakeover,
+            (MarketType::Perp, Some(MarketType::Spot)) => LiquidationType::PerpPnlForDeposit,
+            (MarketType::Spot, Some(MarketType::Perp)) => LiquidationType::BorrowForPerpPnl,
+            (MarketType::Spot, Some(MarketType::Spot)) => LiquidationType::SpotForSpot,
+            _ => LiquidationType::Skip,
+        }
+    }
+
+    /// Calculate collateral requirement for all perp positions
+    fn get_perp_positions_info(
+        market_state: &MarketState,
+        perp_positions: &[PerpPosition],
+    ) -> Vec<PositionInfo> {
+        let state = market_state.load();
+
+        perp_positions
+            .iter()
+            .filter(|p| p.base_asset_amount != 0 || p.quote_asset_amount != 0)
+            .filter_map(|pos| {
+                let perp_market = state.perp_markets.get(&pos.market_index)?;
+                let oracle = state.perp_oracle_prices.get(&pos.market_index)?;
+
+                let margin_ratio = perp_market
+                    .get_margin_ratio(
+                        pos.base_asset_amount.unsigned_abs() as u128,
+                        MarginRequirementType::Initial,
+                        false,
+                    )
+                    .ok()?;
+
+                let collateral = (pos.base_asset_amount.abs() as u128)
+                    .saturating_mul(oracle.price as u128)
+                    .saturating_mul(QUOTE_PRECISION)
+                    .saturating_mul(margin_ratio as u128)
+                    .saturating_div(MARGIN_PRECISION_U128)
+                    .saturating_div(PRICE_PRECISION)
+                    .saturating_div(BASE_PRECISION);
+
+                Some(PositionInfo {
+                    market_type: MarketType::Perp,
+                    market_index: pos.market_index,
+                    is_asset: pos.quote_asset_amount > 0,
+                    collateral_required: collateral as i128,
+                    base_amount: pos.base_asset_amount,
+                    quote_amount: pos.quote_asset_amount,
+                })
+            })
+            .collect()
+    }
+
+    /// Calculate collateral required for all spot positions
+    fn get_spot_positions_info(
+        market_state: &MarketState,
+        spot_positions: &[SpotPosition],
+    ) -> Vec<PositionInfo> {
+        let state = market_state.load();
+
+        spot_positions
+            .iter()
+            .filter(|p| !p.is_available())
+            .filter_map(|pos| {
+                let spot_market = state.spot_markets.get(&pos.market_index)?;
+                let oracle = state.spot_oracle_prices.get(&pos.market_index)?;
+
+                let token_amount = pos.get_signed_token_amount(&spot_market).ok()?;
+
+                let token_precision = 10_u128.pow(spot_market.decimals);
+                let weight = if pos.balance_type == SpotBalanceType::Deposit {
+                    spot_market.initial_asset_weight
+                } else {
+                    spot_market.initial_liability_weight
+                };
+
+                let collateral_impact = (token_amount.abs() as u128)
+                    .saturating_mul(oracle.price as u128)
+                    .saturating_div(PRICE_PRECISION)
+                    .saturating_mul(QUOTE_PRECISION)
+                    .saturating_div(token_precision)
+                    .saturating_mul(weight as u128)
+                    .saturating_div(SPOT_WEIGHT_PRECISION_U128);
+
+                Some(PositionInfo {
+                    market_type: MarketType::Spot,
+                    market_index: pos.market_index,
+                    is_asset: pos.balance_type == SpotBalanceType::Deposit,
+                    collateral_required: collateral_impact as i128,
+                    base_amount: token_amount as i64,
+                    quote_amount: 0,
+                })
+            })
+            .collect()
+    }
+
+    /// Pick the largest liability and best matching asset
+    fn pick_best_asset_liability_combo(
+        perp_positions: &[PositionInfo],
+        spot_positions: &[PositionInfo],
+    ) -> Option<(PositionInfo, Option<PositionInfo>)> {
+        let mut liabilities: Vec<PositionInfo> = perp_positions
+            .iter()
+            .chain(spot_positions)
+            .filter(|p| !p.is_asset)
+            .cloned()
+            .collect();
+
+        let mut assets: Vec<PositionInfo> = perp_positions
+            .iter()
+            .chain(spot_positions)
+            .filter(|p| p.is_asset)
+            .cloned()
+            .collect();
+
+        liabilities.sort_by(|a, b| {
+            b.collateral_required
+                .abs()
+                .cmp(&a.collateral_required.abs())
+        });
+
+        assets.sort_by(|a, b| {
+            b.collateral_required
+                .abs()
+                .cmp(&a.collateral_required.abs())
+        });
+
+        let largest_liability = liabilities.first()?.clone();
+        let best_asset = assets.first().cloned();
+
+        Some((largest_liability, best_asset))
     }
 
     /// Find top makers for a perp position
@@ -1996,7 +2206,7 @@ impl PrimaryLiquidationStrategy {
         );
 
         match method {
-            PerpLiquidationMethod::WithFill => {
+            LiquidationType::PerpWithFill => {
                 try_liquidate_with_match(
                     &drift,
                     pos.market_index,
@@ -2010,7 +2220,7 @@ impl PrimaryLiquidationStrategy {
                     pyth_update,
                 );
             }
-            PerpLiquidationMethod::Takeover => {
+            LiquidationType::PerpTakeover => {
                 try_liquidate_with_collateral(
                     &drift,
                     pos.market_index,
@@ -2024,11 +2234,8 @@ impl PrimaryLiquidationStrategy {
                     pyth_update,
                 );
             }
-            PerpLiquidationMethod::Skip => {
-                log::info!(
-                    target: TARGET,
-                    "skipping liquidation: insufficient collateral and no makers available"
-                );
+            _ => {
+                log::info!(target: TARGET, "skipping liquidation for {:?}", liquidatee);
             }
         }
     }
@@ -2277,39 +2484,85 @@ impl LiquidationStrategy for PrimaryLiquidationStrategy {
         collateral_info_per_subaccount: Arc<RwLock<HashMap<Pubkey, CollateralInfo>>>,
         status: UserMarginStatus,
     ) -> futures_util::future::BoxFuture<'a, ()> {
-        Self::liquidate_perp(
-            &self.drift,
-            self.dlob,
-            Arc::clone(&self.market_state),
-            Arc::clone(&self.metrics),
-            self.keeper_subaccount,
-            liquidatee,
-            Arc::clone(&user_account),
-            tx_sender.clone(),
-            priority_fee,
-            cu_limit,
-            slot,
-            pyth_price_update,
-            collateral_info_per_subaccount,
-            &status,
+        let perp_positions = Self::get_perp_positions_info(
+            self.market_state.read().unwrap(),
+            &user_account.perp_positions,
         );
 
-        if self.use_spot_liquidation {
-            Self::liquidate_spot(
-                self.drift.clone(),
-                Arc::clone(&self.metrics),
-                Arc::clone(&self.market_state),
-                self.keeper_subaccount,
-                liquidatee,
-                user_account,
-                tx_sender.clone(),
-                priority_fee,
-                400_000,
-                slot,
-            )
-            .boxed()
-        } else {
-            async {}.boxed()
+        let spot_positions = Self::get_spot_positions_info(
+            self.market_state.read().unwrap(),
+            &user_account.spot_positions,
+        );
+
+        let Some((liability, asset)) =
+            Self::pick_best_asset_liability_combo(&perp_positions, &spot_positions)
+        else {
+            log::warn!(target: TARGET, "no liquidatable positions for {:?}", liquidatee);
+            return async {}.boxed();
+        };
+
+        let liq_type = Self::decide_liquidation_type(&liability, asset.as_ref());
+
+        match liq_type {
+            LiquidationType::PerpTakeover | LiquidationType::PerpWithFill => {
+                Self::liquidate_perp(
+                    &self.drift,
+                    self.dlob,
+                    self.market_state,
+                    Arc::clone(&self.metrics),
+                    self.keeper_subaccount,
+                    liquidatee,
+                    Arc::clone(&user_account),
+                    tx_sender.clone(),
+                    priority_fee,
+                    cu_limit,
+                    slot,
+                    pyth_price_update,
+                    collateral_info_per_subaccount,
+                );
+                async {}.boxed()
+            }
+            LiquidationType::SpotForSpot => {
+                if self.use_spot_liquidation {
+                    Self::liquidate_spot(
+                        self.drift.clone(),
+                        Arc::clone(&self.metrics),
+                        self.market_state.load(),
+                        self.keeper_subaccount,
+                        liquidatee,
+                        user_account,
+                        tx_sender.clone(),
+                        priority_fee,
+                        400_000,
+                        slot,
+                    )
+                    .boxed()
+                } else {
+                    async {}.boxed()
+                }
+            }
+            LiquidationType::PerpPnlForDeposit => {
+                if let Some(asset) = asset {
+                    try_liquidate_perp_pnl_for_deposit(
+                        &self.drift,
+                        self.keeper_subaccount,
+                        liquidatee,
+                        &liability,
+                        &asset,
+                        tx_sender,
+                        priority_fee,
+                        cu_limit,
+                        slot,
+                        pyth_price_update,
+                    );
+                }
+                async {}.boxed()
+            }
+            LiquidationType::BorrowForPerpPnl => async {}.boxed(),
+            LiquidationType::Skip => {
+                log::info!(target: TARGET, "skipping liquidation for {:?}: insufficient collateral", liquidatee);
+                async {}.boxed()
+            }
         }
     }
 }

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -307,6 +307,7 @@ fn check_margin_status(margin_info: &SimplifiedMarginCalculation) -> UserMarginS
         if calc.total_collateral <= 0 {
             continue;
         }
+
         let buffered_iso_margin_req = (calc.margin_requirement as f64 * LIQUIDATION_BUFFER) as i128;
         if calc.total_collateral < buffered_iso_margin_req {
             isolated.push((calc.market_index, MarginStatus::Liquidatable));

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -11,7 +11,7 @@ use futures_util::FutureExt;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     sync::{Arc, RwLock},
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use tokio::sync::mpsc::error::TryRecvError;
 
@@ -29,7 +29,8 @@ use drift_rs::{
     titan,
     types::{
         accounts::{PerpMarket, SpotMarket, User},
-        MarginRequirementType, MarketId, MarketStatus, MarketType, OracleSource, SpotBalanceType,
+        MarginRequirementType, MarketId, MarketStatus, MarketType, OracleSource, OrderParams,
+        OrderType, PositionDirection, SpotBalanceType,
     },
     DriftClient, GrpcSubscribeOpts, MarketState, Pubkey, TransactionBuilder, Wallet,
 };
@@ -517,6 +518,11 @@ impl LiquidatorBot {
             get_collateral_info_per_subaccount(&drift, &config.get_subaccounts()).await,
         ));
 
+        let cu_limit = std::env::var("FILL_CU_LIMIT")
+            .ok()
+            .and_then(|s| s.parse::<u32>().ok())
+            .unwrap_or(config.fill_cu_limit);
+
         // start liquidation worker
         let (liq_tx, liq_rx) = tokio::sync::mpsc::channel::<(
             Pubkey,
@@ -538,15 +544,26 @@ impl LiquidatorBot {
                 use_spot_liquidation: config.use_spot_liquidation,
             }),
             liq_rx,
-            std::env::var("FILL_CU_LIMIT")
-                .ok()
-                .and_then(|s| s.parse::<u32>().ok())
-                .unwrap_or(config.fill_cu_limit),
+            cu_limit,
             Arc::clone(&priority_fee_subscriber),
             Arc::clone(&collateral_info_per_subaccount),
         );
 
         log::info!(target: TARGET, "spawned liquidation worker");
+        // Spawn derisk loop
+        let subaccounts: Vec<Pubkey> = config
+            .get_subaccounts()
+            .iter()
+            .map(|id| Wallet::derive_user_account(&drift.wallet.authority(), *id))
+            .collect();
+
+        spawn_derisk_loop(
+            drift.clone(),
+            tx_sender.clone(),
+            subaccounts,
+            Arc::clone(&priority_fee_subscriber),
+            cu_limit,
+        );
 
         LiquidatorBot {
             drift,
@@ -1154,6 +1171,81 @@ impl LiquidatorBot {
     }
 }
 
+fn derisk_subaccount(
+    drift: &DriftClient,
+    tx_sender: &TxSender,
+    subaccount: Pubkey,
+    priority_fee: u64,
+    cu_limit: u32,
+) {
+    let user = match drift.try_get_account::<User>(&subaccount) {
+        Ok(u) => u,
+        Err(_) => return,
+    };
+
+    for position in user.perp_positions.iter() {
+        if position.base_asset_amount == 0 && position.quote_asset_amount == 0 {
+            continue;
+        }
+
+        let mut tx_builder = TransactionBuilder::new(
+            drift.program_data(),
+            subaccount,
+            std::borrow::Cow::Owned(user.clone()),
+            false,
+        )
+        .with_priority_fee(priority_fee, Some(cu_limit));
+
+        if position.base_asset_amount != 0 {
+            let direction = if position.base_asset_amount > 0 {
+                PositionDirection::Short
+            } else {
+                PositionDirection::Long
+            };
+
+            tx_builder = tx_builder.place_orders(vec![OrderParams {
+                order_type: OrderType::Market,
+                market_type: MarketType::Perp,
+                direction,
+                base_asset_amount: position.base_asset_amount.unsigned_abs(),
+                market_index: position.market_index,
+                reduce_only: true,
+                ..Default::default()
+            }]);
+        } else {
+            tx_builder = tx_builder.settle_pnl(position.market_index, None, None);
+        }
+
+        tx_sender.send_tx(
+            tx_builder.build(),
+            TxIntent::Derisk {
+                market_index: position.market_index,
+                subaccount,
+            },
+            cu_limit as u64,
+        );
+    }
+}
+
+fn spawn_derisk_loop(
+    drift: DriftClient,
+    tx_sender: TxSender,
+    subaccounts: Vec<Pubkey>,
+    priority_fee_subscriber: Arc<PriorityFeeSubscriber>,
+    cu_limit: u32,
+) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(5));
+        loop {
+            interval.tick().await;
+            let priority_fee = priority_fee_subscriber.priority_fee_nth(0.6);
+            for subaccount in &subaccounts {
+                derisk_subaccount(&drift, &tx_sender, *subaccount, priority_fee, cu_limit);
+            }
+        }
+    });
+}
+
 async fn get_collateral_info_per_subaccount(
     drift: &DriftClient,
     subaccounts: &[u16],
@@ -1202,11 +1294,11 @@ async fn get_collateral_info_per_subaccount(
 }
 
 fn calculate_perp_collateral_requirement(
-    market_state: &MarketState,
+    market_state: Arc<RwLock<MarketState>>,
     market_index: u16,
     base_asset_amount: i64,
 ) -> Option<u128> {
-    let state = market_state.load();
+    let state = market_state.read().unwrap().load();
 
     let perp_market = state.perp_markets.get(&market_index)?;
     let oracle = state.perp_oracle_prices.get(&market_index)?;
@@ -1833,31 +1925,31 @@ impl LiquidateWithMatchStrategy {
 
         let pyth_update = pyth_price_update.filter(|update| update.price != oracle_price);
 
-        // try_liquidate_with_match(
-        //     &drift,
-        //     pos.market_index,
-        //     keeper_subaccount,
-        //     liquidatee,
-        //     makers.as_slice(),
-        //     tx_sender,
-        //     priority_fee,
-        //     cu_limit,
-        //     slot,
-        //     pyth_update,
-        // );
-
-        try_liquidate_with_collateral(
+        try_liquidate_with_match(
             &drift,
             pos.market_index,
             keeper_subaccount,
             liquidatee,
-            pos.base_asset_amount.unsigned_abs(),
+            makers.as_slice(),
             tx_sender,
             priority_fee,
             cu_limit,
             slot,
             pyth_update,
         );
+
+        // try_liquidate_with_collateral(
+        //     &drift,
+        //     pos.market_index,
+        //     keeper_subaccount,
+        //     liquidatee,
+        //     pos.base_asset_amount.unsigned_abs(),
+        //     tx_sender,
+        //     priority_fee,
+        //     cu_limit,
+        //     slot,
+        //     pyth_update,
+        // );
     }
 
     /// Attempt spot liquidation with Jupiter swap

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -592,7 +592,7 @@ impl LiquidatorBot {
                     // Check margin status and add to high-risk set if needed
                     let status = check_margin_status(&margin_info);
 
-                    if status.is_at_risk(){
+                    if status.is_at_risk() {
                         high_risk.insert(*pubkey);
                         initial_high_risk_count += 1;
                     }
@@ -607,7 +607,13 @@ impl LiquidatorBot {
         let mut oracle_update;
 
         // Pyth Feed
-        let mut pyth_price_feed = self.pyth_price_feed.unwrap();
+        let mut pyth_price_feed = match self.pyth_price_feed {
+            Some(rx) => rx,
+            None => {
+                log::error!(target: TARGET, "pyth price feed not initialized");
+                return;
+            }
+        };
         let mut pyth_perp_prices = BTreeMap::<u16, PythPriceUpdate>::new();
 
         loop {

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -579,8 +579,8 @@ impl LiquidatorBot {
                     Some(liquidation_margin_buffer_ratio),
                 ) {
                     Ok(info) => info,
-                    Err(e) => {
-                        log::warn!(target: TARGET, "margin calc failed for {:?}: {:?}", pubkey, e);
+                    Err(_e) => {
+                        log::warn!(target: TARGET, "margin calc failed for {:?}", pubkey);
                         return;
                     }
                 };
@@ -719,8 +719,8 @@ impl LiquidatorBot {
                                     Some(liquidation_margin_buffer_ratio),
                                 ) {
                                 Ok(info) => info,
-                                Err(e) => {
-                                    log::warn!(target: TARGET, "margin calc failed for {:?}: {:?}", pubkey, e);
+                                Err(_e) => {
+                                    log::warn!(target: TARGET, "margin calc failed for {:?}", pubkey);
                                     continue;
                                 }
                             };
@@ -844,8 +844,8 @@ impl LiquidatorBot {
                                 Some(liquidation_margin_buffer_ratio),
                             ) {
                             Ok(info) => info,
-                            Err(e) => {
-                                log::warn!(target: TARGET, "margin calc failed for {:?}: {:?}", pubkey, e);
+                            Err(_e) => {
+                                log::warn!(target: TARGET, "margin calc failed for {:?}", pubkey);
                                 continue;
                             }
                         };
@@ -1016,19 +1016,18 @@ impl LiquidatorBot {
                         }
                     }
 
-                    let margin_info = match self
-                        .market_state
-                        .calculate_simplified_margin_requirement(
+                    let margin_info =
+                        match self.market_state.calculate_simplified_margin_requirement(
                             &user_meta.user,
                             MarginRequirementType::Maintenance,
                             Some(liquidation_margin_buffer_ratio),
                         ) {
-                        Ok(info) => info,
-                        Err(e) => {
-                            log::warn!(target: TARGET, "margin calc failed for {:?}: {:?}", pubkey, e);
-                            continue;
-                        }
-                    };
+                            Ok(info) => info,
+                            Err(_e) => {
+                                log::warn!(target: TARGET, "margin calc failed for {:?}", pubkey);
+                                continue;
+                            }
+                        };
 
                     let status = check_margin_status(&margin_info);
 

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -1544,11 +1544,9 @@ impl LiquidateWithMatchStrategy {
         // Check isolated liquidations first
         for (market_index, iso_status) in &status.isolated {
             if *iso_status == MarginStatus::Liquidatable {
-                if let Some(pos) = user_account
-                    .perp_positions
-                    .iter()
-                    .find(|p| p.market_index == *market_index && p.base_asset_amount != 0)
-                {
+                if let Some(pos) = user_account.perp_positions.iter().find(|p| {
+                    p.market_index == *market_index && p.isolated_position_scaled_balance != 0
+                }) {
                     metrics
                         .liquidation_attempts
                         .with_label_values(&["perp"])

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -18,7 +18,7 @@ use tokio::sync::mpsc::error::TryRecvError;
 
 use drift_rs::{
     dlob::{DLOBNotifier, DLOB},
-    ffi::{OraclePriceData, SimplifiedMarginCalculation},
+    ffi::{calculate_claimable_pnl, OraclePriceData, SimplifiedMarginCalculation},
     grpc::{
         grpc_subscriber::{AccountFilter, GrpcConnectionOpts},
         TransactionUpdate,
@@ -27,8 +27,8 @@ use drift_rs::{
     market_state::MarketStateData,
     math::{
         constants::{
-            BASE_PRECISION, BASE_PRECISION_U64, MARGIN_PRECISION_U128, PRICE_PRECISION,
-            QUOTE_PRECISION, QUOTE_PRECISION_U64, SPOT_WEIGHT_PRECISION_U128,
+            BASE_PRECISION, MARGIN_PRECISION_U128, PRICE_PRECISION, QUOTE_PRECISION,
+            SPOT_WEIGHT_PRECISION_U128,
         },
         liquidation::{calculate_collateral, CollateralInfo},
         tiers::perp_tier_is_as_safe_as,
@@ -1731,7 +1731,7 @@ pub struct PrimaryLiquidationStrategy {
 }
 
 impl PrimaryLiquidationStrategy {
-    /// Liquidation policy: Prefer takeover for small positions (<=$5k), use makers for large positions,
+    /// Liquidation policy: Prefer takeover for small positions, use makers for large positions,
     /// fallback to takeover when no makers available. Skip if no makers and insufficient collateral.
     fn decide_perp_method(
         quote_asset_amount: u64,
@@ -1739,20 +1739,23 @@ impl PrimaryLiquidationStrategy {
         collateral_required: u128,
         has_makers: bool,
     ) -> LiquidationType {
-        const POSITION_AMOUNT_THRESHOLD: u64 = 5_000 * QUOTE_PRECISION_U64;
+        // const POSITION_AMOUNT_THRESHOLD: u64 = 5_000 * QUOTE_PRECISION_U64;
 
-        let is_small_position = quote_asset_amount <= POSITION_AMOUNT_THRESHOLD;
-        let can_afford_takeover = collateral_available >= collateral_required;
+        // let is_small_position = quote_asset_amount <= POSITION_AMOUNT_THRESHOLD;
+        // let can_afford_takeover = collateral_available >= collateral_required;
 
-        if is_small_position && can_afford_takeover {
-            LiquidationType::PerpTakeover
-        } else if has_makers {
-            LiquidationType::PerpWithFill
-        } else if can_afford_takeover {
-            LiquidationType::PerpTakeover
-        } else {
-            LiquidationType::Skip
-        }
+        // if is_small_position && can_afford_takeover {
+        //     LiquidationType::PerpTakeover
+        // } else if has_makers {
+        //     LiquidationType::PerpWithFill
+        // } else if can_afford_takeover {
+        //     LiquidationType::PerpTakeover
+        // } else {
+        //     LiquidationType::Skip
+        // }
+
+        // For testing just use Fill
+        LiquidationType::PerpWithFill
     }
 
     fn decide_liquidation_type(
@@ -3314,24 +3317,24 @@ impl LiquidationStrategy for PrimaryLiquidationStrategy {
 
         async move {
             match liq_type {
-                LiquidationType::SettlePnl => {
-                    let markets: Vec<u16> = perp_positions
-                        .iter()
-                        .filter(|p| p.base_amount == 0 && p.quote_amount != 0 && p.is_asset)
-                        .map(|p| p.market_index)
-                        .collect();
+                // LiquidationType::SettlePnl => {
+                //     let markets: Vec<u16> = perp_positions
+                //         .iter()
+                //         .filter(|p| p.base_amount == 0 && p.quote_amount != 0 && p.is_asset)
+                //         .map(|p| p.market_index)
+                //         .collect();
 
-                    Self::settle_perp_pnl(
-                        &self.drift,
-                        self.subaccounts[0],
-                        liquidatee,
-                        &markets,
-                        tx_sender,
-                        priority_fee,
-                        cu_limit,
-                    )
-                    .await;
-                }
+                //     Self::settle_perp_pnl(
+                //         &self.drift,
+                //         self.subaccounts[0],
+                //         liquidatee,
+                //         &markets,
+                //         tx_sender,
+                //         priority_fee,
+                //         cu_limit,
+                //     )
+                //     .await;
+                // }
                 LiquidationType::PerpTakeover | LiquidationType::PerpWithFill => {
                     Self::liquidate_perp(
                         &self,
@@ -3348,7 +3351,8 @@ impl LiquidationStrategy for PrimaryLiquidationStrategy {
                         slot,
                         pyth_price_update,
                         &status,
-                    ).await;
+                    )
+                    .await;
                 }
                 LiquidationType::SpotForSpot => {
                     if self.use_spot_liquidation {
@@ -3363,51 +3367,54 @@ impl LiquidationStrategy for PrimaryLiquidationStrategy {
                             priority_fee,
                             400_000,
                             slot,
-                        ).await;
-                    }
-                }
-                LiquidationType::PerpPnlForDeposit => {
-                    if let Some(asset) = asset {
-                        Self::liquidate_perp_pnl_for_deposit(
-                            &self,
-                            &self.drift,
-                            Arc::clone(&self.market_state),
-                            self.subaccounts.as_slice(),
-                            liquidatee,
-                            liability,
-                            asset,
-                            tx_sender,
-                            priority_fee,
-                            cu_limit,
-                            slot,
-                            pyth_price_update,
                         )
                         .await;
                     }
                 }
-                LiquidationType::BorrowForPerpPnl => {
-                    if let Some(asset) = asset {
-                        Self::liquidate_borrow_for_perp_pnl(
-                            &self,
-                            &self.drift,
-                            Arc::clone(&self.market_state),
-                            self.subaccounts.as_slice(),
-                            liquidatee,
-                            liability,
-                            asset,
-                            tx_sender,
-                            priority_fee,
-                            cu_limit,
-                            slot,
-                            pyth_price_update,
-                        )
-                        .await;
-                    }
-                }
-                LiquidationType::Skip => {
-                    log::info!(target: TARGET, "skipping liquidation for {:?}: insufficient collateral", liquidatee);
-                }
+                // LiquidationType::PerpPnlForDeposit => {
+                //     if let Some(asset) = asset {
+                //         Self::liquidate_perp_pnl_for_deposit(
+                //             &self,
+                //             &self.drift,
+                //             Arc::clone(&self.market_state),
+                //             self.subaccounts.as_slice(),
+                //             liquidatee,
+                //             liability,
+                //             asset,
+                //             tx_sender,
+                //             priority_fee,
+                //             cu_limit,
+                //             slot,
+                //             pyth_price_update,
+                //         )
+                //         .await;
+                //     }
+                // }
+                // LiquidationType::BorrowForPerpPnl => {
+                //     if let Some(asset) = asset {
+                //         Self::liquidate_borrow_for_perp_pnl(
+                //             &self,
+                //             &self.drift,
+                //             Arc::clone(&self.market_state),
+                //             self.subaccounts.as_slice(),
+                //             liquidatee,
+                //             liability,
+                //             asset,
+                //             tx_sender,
+                //             priority_fee,
+                //             cu_limit,
+                //             slot,
+                //             pyth_price_update,
+                //         )
+                //         .await;
+                //     }
+                // }
+                // LiquidationType::Skip => {
+                //     log::info!(target: TARGET, "skipping liquidation for {:?}: insufficient collateral", liquidatee);
+                // }
+                _ => {}
             }
-        }.boxed()
+        }
+        .boxed()
     }
 }

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -304,6 +304,11 @@ fn check_margin_status(margin_info: &SimplifiedMarginCalculation) -> UserMarginS
             let buffered_iso_margin_req =
                 (calc.margin_requirement as f64 * LIQUIDATION_BUFFER) as i128;
             if calc.total_collateral < buffered_iso_margin_req {
+                log::info!(
+                    target: TARGET,
+                    "found liquidatable isolated position user: {:?}",
+                    calc
+                );
                 isolated.push((calc.market_index, MarginStatus::Liquidatable));
             } else {
                 let free_margin = calc.total_collateral - calc.margin_requirement as i128;

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -505,7 +505,7 @@ impl LiquidatorBot {
             u64,
             Option<PythPriceUpdate>,
             UserMarginStatus,
-        )>(1024);
+        )>(10240);
         spawn_liquidation_worker(
             tx_sender.clone(),
             // TODO: apply your own liquidation strategy here
@@ -783,6 +783,7 @@ impl LiquidatorBot {
             // Process in batches to avoid blocking the main event loop
             if oracle_update {
                 let _high_risk_count = high_risk.len();
+
                 let t0 = current_time_millis();
                 let mut liquidatable_users = Vec::new();
 
@@ -884,7 +885,7 @@ impl LiquidatorBot {
                     )) {
                         Ok(()) => {}
                         Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                            log::debug!(
+                            log::warn!(
                                 target: TARGET,
                                 "liquidation channel full, dropping liquidation for {:?}",
                                 pubkey
@@ -1062,7 +1063,7 @@ impl LiquidatorBot {
                         )) {
                             Ok(()) => {}
                             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                                log::debug!(
+                                log::warn!(
                                     target: TARGET,
                                     "liquidation channel full, dropping liquidation for {:?}",
                                     pubkey
@@ -1123,7 +1124,7 @@ async fn setup_grpc(
     transaction_tx: TxSender,
     market_ids: Vec<MarketId>,
 ) -> tokio::sync::mpsc::Receiver<GrpcEvent> {
-    let (tx, rx) = tokio::sync::mpsc::channel(1024);
+    let (tx, rx) = tokio::sync::mpsc::channel(10240);
 
     let _ = tokio::try_join!(
         crate::filler::sync_stats_accounts(&drift),
@@ -1167,7 +1168,7 @@ async fn setup_grpc(
                                 user: user.clone(),
                                 slot: acc.slot,
                             }) {
-                                log::error!(target: TARGET, "failed to forward event: {err:?}");
+                                log::error!(target: TARGET, "failed to forward user update event: {err:?}");
                             }
                         }
                     },
@@ -1182,7 +1183,7 @@ async fn setup_grpc(
                                 market: market.clone(),
                                 slot: acc.slot,
                             }) {
-                                log::error!(target: TARGET, "failed to forward event: {err:?}");
+                                log::error!(target: TARGET, "failed to forward perp market update event: {err:?}");
                             }
                         }
                     },
@@ -1197,7 +1198,7 @@ async fn setup_grpc(
                                 market: market.clone(),
                                 slot: acc.slot,
                             }) {
-                                log::error!(target: TARGET, "failed to forward event: {err:?}");
+                                log::error!(target: TARGET, "failed to forward spot market update event: {err:?}");
                             }
                         }
                     },
@@ -1231,7 +1232,7 @@ async fn setup_grpc(
                                 market: *market,
                                 slot: acc.slot,
                             }) {
-                                log::error!(target: TARGET, "failed to forward event: {err:?}");
+                                log::error!(target: TARGET, "failed to forward oracle update event: {err:?}");
                             }
                         }
                     }
@@ -1356,7 +1357,6 @@ fn spawn_liquidation_worker(
             }
 
             let pf = priority_fee_subscriber.priority_fee_nth(0.6);
-
             let strategy_clone = Arc::clone(&strategy);
             let liquidatee_clone = liquidatee;
             let user_account_clone = Arc::new(user_account);
@@ -1496,9 +1496,11 @@ impl LiquidateWithMatchStrategy {
         // Check isolated liquidations first
         for (market_index, iso_status) in &status.isolated {
             if *iso_status == MarginStatus::Liquidatable {
-                if let Some(pos) = user_account.perp_positions.iter().find(|p| {
-                    p.market_index == *market_index && p.isolated_position_scaled_balance != 0
-                }) {
+                if let Some(pos) = user_account
+                    .perp_positions
+                    .iter()
+                    .find(|p| p.market_index == *market_index && p.base_asset_amount != 0)
+                {
                     metrics
                         .liquidation_attempts
                         .with_label_values(&["perp"])

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -218,11 +218,17 @@ async fn update_dashboard_state(
                     // Note: base_asset_amount calculation would require spot market access
                     // which isn't directly available from MarketState in this context.
                     // We'll calculate an approximation using scaled_balance and oracle price.
-                    let spot_market = drift.try_get_spot_market_account(pos.market_index).unwrap();
+                    let spot_market = match drift.try_get_spot_market_account(pos.market_index) {
+                        Ok(market) => market,
+                        Err(_) => continue,
+                    };
                     let (base, quote) = if let Some(oracle_meta) =
                         oracle_prices.get(&MarketId::spot(pos.market_index))
                     {
-                        let base = pos.get_signed_token_amount(&spot_market).unwrap();
+                        let base = match pos.get_signed_token_amount(&spot_market) {
+                            Ok(amount) => amount,
+                            Err(_) => continue,
+                        };
                         (base, base * oracle_meta.price_data.price as i128)
                     } else {
                         (0, 0) // No oracle price available

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -9,7 +9,6 @@
 use anchor_lang::Discriminator;
 use futures_util::FutureExt;
 use std::{
-    cmp::Reverse,
     collections::{BTreeMap, HashMap, HashSet},
     sync::{Arc, RwLock},
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -18,7 +17,7 @@ use tokio::sync::mpsc::error::TryRecvError;
 
 use drift_rs::{
     dlob::{DLOBNotifier, DLOB},
-    ffi::{spot_position_get_signed_token_amount, OraclePriceData, SimplifiedMarginCalculation},
+    ffi::{OraclePriceData, SimplifiedMarginCalculation},
     grpc::{grpc_subscriber::AccountFilter, TransactionUpdate},
     jupiter::SwapMode,
     market_state::MarketStateData,
@@ -1658,9 +1657,10 @@ fn try_liquidate_perp_pnl_for_deposit(
 
     tx_builder = tx_builder.liquidate_perp_pnl_for_deposit(
         &liquidatee_account,
-        asset.market_index,
         liability.market_index,
-        base_asset_amount,
+        asset.market_index,
+        drift_rs::types::u128::from(liability.collateral_required.unsigned_abs()),
+        None,
     );
 
     let tx = tx_builder.build();
@@ -1670,6 +1670,68 @@ fn try_liquidate_perp_pnl_for_deposit(
         TxIntent::LiquidatePerpPnlForDeposit {
             perp_market_index: liability.market_index,
             spot_market_index: asset.market_index,
+            liquidatee,
+            slot,
+        },
+        cu_limit as u64,
+    );
+}
+
+fn try_liquidate_borrow_for_perp_pnl(
+    drift: &DriftClient,
+    keeper_subaccount: Pubkey,
+    liquidatee: Pubkey,
+    liability: &PositionInfo,
+    asset: &PositionInfo,
+    tx_sender: TxSender,
+    priority_fee: u64,
+    cu_limit: u32,
+    slot: u64,
+    pyth_price_update: Option<PythPriceUpdate>,
+) {
+    let keeper_account = match drift.try_get_account::<User>(&keeper_subaccount) {
+        Ok(data) => data,
+        Err(_) => {
+            log::warn!(target: TARGET, "keeper account not found");
+            return;
+        }
+    };
+
+    let liquidatee_account = match drift.try_get_account::<User>(&liquidatee) {
+        Ok(data) => data,
+        Err(_) => {
+            log::warn!(target: TARGET, "liquidatee account not found");
+            return;
+        }
+    };
+
+    let mut tx_builder = TransactionBuilder::new(
+        drift.program_data(),
+        keeper_subaccount,
+        std::borrow::Cow::Owned(keeper_account),
+        false,
+    )
+    .with_priority_fee(priority_fee, Some(cu_limit));
+
+    if let Some(ref update) = pyth_price_update {
+        tx_builder = tx_builder.post_pyth_lazer_oracle_update(&[update.feed_id], &update.message);
+    }
+
+    tx_builder = tx_builder.liquidate_borrow_for_perp_pnl(
+        &liquidatee_account,
+        asset.market_index,
+        liability.market_index,
+        drift_rs::types::u128::from(liability.base_amount.unsigned_abs() as u128),
+        None,
+    );
+
+    let tx = tx_builder.build();
+
+    tx_sender.send_tx(
+        tx,
+        TxIntent::LiquidateBorrowForPerpPnl {
+            perp_market_index: asset.market_index,
+            spot_market_index: liability.market_index,
             liquidatee,
             slot,
         },
@@ -1850,10 +1912,10 @@ impl PrimaryLiquidationStrategy {
 
     /// Calculate collateral requirement for all perp positions
     fn get_perp_positions_info(
-        market_state: &MarketState,
+        market_state: Arc<RwLock<MarketState>>,
         perp_positions: &[PerpPosition],
     ) -> Vec<PositionInfo> {
-        let state = market_state.load();
+        let state = market_state.read().unwrap().load();
 
         perp_positions
             .iter()
@@ -1892,10 +1954,10 @@ impl PrimaryLiquidationStrategy {
 
     /// Calculate collateral required for all spot positions
     fn get_spot_positions_info(
-        market_state: &MarketState,
+        market_state: Arc<RwLock<MarketState>>,
         spot_positions: &[SpotPosition],
     ) -> Vec<PositionInfo> {
-        let state = market_state.load();
+        let state = market_state.read().unwrap().load();
 
         spot_positions
             .iter()
@@ -2114,7 +2176,7 @@ impl PrimaryLiquidationStrategy {
 
         // Calculate collateral required
         let Some(collateral_required) = calculate_perp_collateral_requirement(
-            market_state,
+            Arc::clone(&market_state),
             pos.market_index,
             pos.base_asset_amount,
         ) else {
@@ -2144,35 +2206,7 @@ impl PrimaryLiquidationStrategy {
             .with_label_values(&["perp"])
             .inc();
 
-        let oracle_price = market_state
-            .get_perp_oracle_price(pos.market_index)
-            .map(|x| x.price)
-            .unwrap_or(0) as u64;
-
-        let pyth_update = pyth_price_update.filter(|update| update.price != oracle_price);
-
-        let makers = Self::find_top_makers(
-            drift,
-            dlob,
-            Arc::clone(&market_state),
-            pos.market_index,
-            pos.base_asset_amount,
-        ) else {
-            try_liquidate_with_collateral(
-                &drift,
-                pos.market_index,
-                keeper_subaccount,
-                liquidatee,
-                base_asset_amount_to_be_liquidated,
-                tx_sender,
-                priority_fee,
-                cu_limit,
-                slot,
-                pyth_update,
-            );
-            return;
-        };
-
+        // Get oracle price and pyth update once
         let oracle_price = {
             let state = market_state.read().unwrap();
             match state.get_perp_oracle_price(pos.market_index) {
@@ -2186,17 +2220,13 @@ impl PrimaryLiquidationStrategy {
 
         let pyth_update = pyth_price_update.filter(|update| update.price != oracle_price);
 
-        try_liquidate_with_match(
-            &drift,
+        // Find makers and decide method
+        let makers = Self::find_top_makers(
+            drift,
+            dlob,
+            Arc::clone(&market_state),
             pos.market_index,
-            keeper_subaccount,
-            liquidatee,
-            makers.as_slice(),
-            tx_sender,
-            priority_fee,
-            cu_limit,
-            slot,
-            pyth_update,
+            pos.base_asset_amount,
         );
 
         let method = Self::decide_perp_method(
@@ -2209,7 +2239,7 @@ impl PrimaryLiquidationStrategy {
         match method {
             LiquidationType::PerpWithFill => {
                 try_liquidate_with_match(
-                    &drift,
+                    drift,
                     pos.market_index,
                     keeper_subaccount,
                     liquidatee,
@@ -2223,7 +2253,7 @@ impl PrimaryLiquidationStrategy {
             }
             LiquidationType::PerpTakeover => {
                 try_liquidate_with_collateral(
-                    &drift,
+                    drift,
                     pos.market_index,
                     keeper_subaccount,
                     liquidatee,
@@ -2486,12 +2516,12 @@ impl LiquidationStrategy for PrimaryLiquidationStrategy {
         status: UserMarginStatus,
     ) -> futures_util::future::BoxFuture<'a, ()> {
         let perp_positions = Self::get_perp_positions_info(
-            self.market_state.read().unwrap(),
+            Arc::clone(&self.market_state),
             &user_account.perp_positions,
         );
 
         let spot_positions = Self::get_spot_positions_info(
-            self.market_state.read().unwrap(),
+            Arc::clone(&self.market_state),
             &user_account.spot_positions,
         );
 
@@ -2509,7 +2539,7 @@ impl LiquidationStrategy for PrimaryLiquidationStrategy {
                 Self::liquidate_perp(
                     &self.drift,
                     self.dlob,
-                    self.market_state,
+                    Arc::clone(&self.market_state),
                     Arc::clone(&self.metrics),
                     self.keeper_subaccount,
                     liquidatee,
@@ -2520,6 +2550,7 @@ impl LiquidationStrategy for PrimaryLiquidationStrategy {
                     slot,
                     pyth_price_update,
                     collateral_info_per_subaccount,
+                    &status,
                 );
                 async {}.boxed()
             }
@@ -2528,7 +2559,7 @@ impl LiquidationStrategy for PrimaryLiquidationStrategy {
                     Self::liquidate_spot(
                         self.drift.clone(),
                         Arc::clone(&self.metrics),
-                        self.market_state.load(),
+                        Arc::clone(&self.market_state),
                         self.keeper_subaccount,
                         liquidatee,
                         user_account,
@@ -2559,7 +2590,23 @@ impl LiquidationStrategy for PrimaryLiquidationStrategy {
                 }
                 async {}.boxed()
             }
-            LiquidationType::BorrowForPerpPnl => async {}.boxed(),
+            LiquidationType::BorrowForPerpPnl => {
+                if let Some(asset) = asset {
+                    try_liquidate_borrow_for_perp_pnl(
+                        &self.drift,
+                        self.keeper_subaccount,
+                        liquidatee,
+                        &liability,
+                        &asset,
+                        tx_sender,
+                        priority_fee,
+                        cu_limit,
+                        slot,
+                        pyth_price_update,
+                    );
+                }
+                async {}.boxed()
+            }
             LiquidationType::Skip => {
                 log::info!(target: TARGET, "skipping liquidation for {:?}: insufficient collateral", liquidatee);
                 async {}.boxed()

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -300,23 +300,22 @@ fn check_margin_status(margin_info: &SimplifiedMarginCalculation) -> UserMarginS
 
     // Check isolated positions
     for calc in &margin_info.isolated_margin_calculations {
-        if !calc.is_empty() {
-            let buffered_iso_margin_req =
-                (calc.margin_requirement as f64 * LIQUIDATION_BUFFER) as i128;
-            if calc.total_collateral < buffered_iso_margin_req {
-                log::info!(
-                    target: TARGET,
-                    "found liquidatable isolated position user: {:?}",
-                    calc
-                );
-                isolated.push((calc.market_index, MarginStatus::Liquidatable));
-            } else {
-                let free_margin = calc.total_collateral - calc.margin_requirement as i128;
-                if calc.margin_requirement > 0 && free_margin > 0 {
-                    let free_margin_ratio = free_margin as f64 / calc.margin_requirement as f64;
-                    if free_margin_ratio < HIGH_RISK_FREE_MARGIN_RATIO {
-                        isolated.push((calc.market_index, MarginStatus::HighRisk));
-                    }
+        if calc.is_empty() {
+            continue;
+        }
+
+        if calc.total_collateral <= 0 {
+            continue;
+        }
+        let buffered_iso_margin_req = (calc.margin_requirement as f64 * LIQUIDATION_BUFFER) as i128;
+        if calc.total_collateral < buffered_iso_margin_req {
+            isolated.push((calc.market_index, MarginStatus::Liquidatable));
+        } else {
+            let free_margin = calc.total_collateral - calc.margin_requirement as i128;
+            if calc.margin_requirement > 0 && free_margin > 0 {
+                let free_margin_ratio = free_margin as f64 / calc.margin_requirement as f64;
+                if free_margin_ratio < HIGH_RISK_FREE_MARGIN_RATIO {
+                    isolated.push((calc.market_index, MarginStatus::HighRisk));
                 }
             }
         }

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -621,6 +621,8 @@ impl LiquidatorBot {
         };
         let mut pyth_perp_prices = BTreeMap::<u16, PythPriceUpdate>::new();
 
+        log::info!(target: TARGET, "entering main event loop");
+
         loop {
             oracle_update = false;
 
@@ -628,6 +630,8 @@ impl LiquidatorBot {
             'pyth: loop {
                 match pyth_price_feed.try_recv() {
                     Ok(update) => {
+                        log::info!(target: TARGET, "processing pyth m={}", update.market_id);
+
                         let market_id = update.market_id;
                         let price = update.price;
 
@@ -652,7 +656,10 @@ impl LiquidatorBot {
                     Err(TryRecvError::Empty) => break 'pyth,
                 }
             }
+
+            log::info!(target: TARGET, "calling events_rx.recv_many");
             events_rx.recv_many(&mut event_buffer, 64).await;
+            log::info!(target: TARGET, "got {} events", event_buffer.len());
             for event in event_buffer.drain(..) {
                 match event {
                     GrpcEvent::UserUpdate {
@@ -1432,7 +1439,7 @@ impl LiquidateWithMatchStrategy {
         market_index: u16,
         base_asset_amount: i64,
     ) -> Option<Vec<User>> {
-        let l3_book = dlob.get_l3_snapshot(market_index, MarketType::Perp);
+        let l3_book = dlob.get_l3_snapshot_safe(market_index, MarketType::Perp)?;
 
         let oracle_price = market_state
             .get_perp_oracle_price(market_index)

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -182,7 +182,10 @@ async fn update_dashboard_state(
                 Some(liquidation_margin_buffer_ratio),
             ) {
                 Ok(info) => info,
-                Err(_) => continue,
+                Err(e) => {
+                    std::mem::forget(e);
+                    continue;
+                }
             };
 
             let free_margin = margin_info.total_collateral - margin_info.margin_requirement as i128;
@@ -579,7 +582,8 @@ impl LiquidatorBot {
                     Some(liquidation_margin_buffer_ratio),
                 ) {
                     Ok(info) => info,
-                    Err(_e) => {
+                    Err(e) => {
+                        std::mem::forget(e);
                         log::warn!(target: TARGET, "margin calc failed for {:?}", pubkey);
                         return;
                     }
@@ -719,7 +723,8 @@ impl LiquidatorBot {
                                     Some(liquidation_margin_buffer_ratio),
                                 ) {
                                 Ok(info) => info,
-                                Err(_e) => {
+                                Err(e) => {
+                                    std::mem::forget(e);
                                     log::warn!(target: TARGET, "margin calc failed for {:?}", pubkey);
                                     continue;
                                 }
@@ -844,7 +849,8 @@ impl LiquidatorBot {
                                 Some(liquidation_margin_buffer_ratio),
                             ) {
                             Ok(info) => info,
-                            Err(_e) => {
+                            Err(e) => {
+                                std::mem::forget(e);
                                 log::warn!(target: TARGET, "margin calc failed for {:?}", pubkey);
                                 continue;
                             }
@@ -947,7 +953,10 @@ impl LiquidatorBot {
                                 Some(liquidation_margin_buffer_ratio),
                             ) {
                                 Ok(info) => info,
-                                Err(_) => return false,
+                                Err(e) => {
+                                    std::mem::forget(e);
+                                    return false;
+                                }
                             };
 
                         check_margin_status(&margin_info).is_at_risk()
@@ -1023,7 +1032,8 @@ impl LiquidatorBot {
                             Some(liquidation_margin_buffer_ratio),
                         ) {
                             Ok(info) => info,
-                            Err(_e) => {
+                            Err(e) => {
+                                std::mem::forget(e);
                                 log::warn!(target: TARGET, "margin calc failed for {:?}", pubkey);
                                 continue;
                             }

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -1460,10 +1460,10 @@ impl LiquidateWithMatchStrategy {
     ) -> Option<Vec<User>> {
         let l3_book = dlob.get_l3_snapshot_safe(market_index, MarketType::Perp)?;
 
-        let oracle_price = market_state
-            .get_perp_oracle_price(market_index)
-            .map(|x| x.price)
-            .unwrap_or(0) as u64;
+        let oracle_price = match market_state.get_perp_oracle_price(market_index) {
+            Some(data) if data.price > 0 => data.price as u64,
+            _ => return None,
+        };
 
         let maker_pubkeys: Vec<Pubkey> = if base_asset_amount >= 0 {
             // only want maker orders so don't pass vamm or trigger price

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -22,7 +22,10 @@ use drift_rs::{
     jupiter::SwapMode,
     market_state::MarketStateData,
     math::{
-        constants::{BASE_PRECISION, MARGIN_PRECISION_U128, PRICE_PRECISION, QUOTE_PRECISION},
+        constants::{
+            BASE_PRECISION, BASE_PRECISION_U64, MARGIN_PRECISION_U128, PRICE_PRECISION,
+            QUOTE_PRECISION,
+        },
         liquidation::{calculate_collateral, CollateralInfo},
     },
     priority_fee_subscriber::PriorityFeeSubscriber,
@@ -535,7 +538,7 @@ impl LiquidatorBot {
         spawn_liquidation_worker(
             tx_sender.clone(),
             // TODO: apply your own liquidation strategy here
-            Arc::new(LiquidateWithMatchStrategy {
+            Arc::new(PrimaryLiquidationStrategy {
                 dlob,
                 drift: drift.clone(),
                 market_state: Arc::clone(&market_state),
@@ -1716,9 +1719,13 @@ fn spawn_liquidation_worker(
     });
 }
 
-/// Default liquidation strategy that matches against top-of-book makers and
-/// submits liquidate_with_fill
-pub struct LiquidateWithMatchStrategy {
+enum PerpLiquidationMethod {
+    WithFill,
+    Takeover,
+    Skip,
+}
+/// Primary liquidation strategy: Prefers takeover for large positions, uses maker matching for rest
+pub struct PrimaryLiquidationStrategy {
     pub drift: DriftClient,
     pub dlob: &'static DLOB,
     pub market_state: Arc<RwLock<MarketState>>,
@@ -1727,7 +1734,31 @@ pub struct LiquidateWithMatchStrategy {
     pub use_spot_liquidation: bool,
 }
 
-impl LiquidateWithMatchStrategy {
+impl PrimaryLiquidationStrategy {
+    /// Liquidation policy: Prefer takeover for large positions (≥$10k), use makers for small positions,
+    /// fallback to takeover when no makers available. Skip if no makers and insufficient collateral.
+    fn decide_perp_method(
+        base_asset_amount_to_liquidate: u64,
+        collateral_available: i128,
+        collateral_required: u128,
+        has_makers: bool,
+    ) -> PerpLiquidationMethod {
+        const LARGE_POSITION_THRESHOLD: u64 = 10_000 * BASE_PRECISION_U64;
+
+        let is_large_position = base_asset_amount_to_liquidate >= LARGE_POSITION_THRESHOLD;
+        let can_afford_takeover = collateral_available >= collateral_required as i128;
+
+        if is_large_position && can_afford_takeover {
+            PerpLiquidationMethod::Takeover
+        } else if has_makers {
+            PerpLiquidationMethod::WithFill
+        } else if can_afford_takeover {
+            PerpLiquidationMethod::Takeover
+        } else {
+            PerpLiquidationMethod::Skip
+        }
+    }
+
     /// Find top makers for a perp position
     fn find_top_makers(
         drift: &DriftClient,
@@ -1781,7 +1812,7 @@ impl LiquidateWithMatchStrategy {
         Some(makers)
     }
 
-    /// Attempt perp liquidation with order matching
+    /// Attempt perp liquidation with order matching or collateral
     fn liquidate_perp(
         drift: &DriftClient,
         dlob: &'static DLOB,
@@ -1909,7 +1940,7 @@ impl LiquidateWithMatchStrategy {
 
         let pyth_update = pyth_price_update.filter(|update| update.price != oracle_price);
 
-        let Some(makers) = Self::find_top_makers(
+        let makers = Self::find_top_makers(
             drift,
             dlob,
             Arc::clone(&market_state),
@@ -1956,6 +1987,50 @@ impl LiquidateWithMatchStrategy {
             slot,
             pyth_update,
         );
+
+        let method = Self::decide_perp_method(
+            base_asset_amount_to_be_liquidated,
+            collateral_info.free,
+            collateral_required,
+            makers.is_some(),
+        );
+
+        match method {
+            PerpLiquidationMethod::WithFill => {
+                try_liquidate_with_match(
+                    &drift,
+                    pos.market_index,
+                    keeper_subaccount,
+                    liquidatee,
+                    makers.unwrap().as_slice(),
+                    tx_sender,
+                    priority_fee,
+                    cu_limit,
+                    slot,
+                    pyth_update,
+                );
+            }
+            PerpLiquidationMethod::Takeover => {
+                try_liquidate_with_collateral(
+                    &drift,
+                    pos.market_index,
+                    keeper_subaccount,
+                    liquidatee,
+                    base_asset_amount_to_be_liquidated,
+                    tx_sender,
+                    priority_fee,
+                    cu_limit,
+                    slot,
+                    pyth_update,
+                );
+            }
+            PerpLiquidationMethod::Skip => {
+                log::info!(
+                    target: TARGET,
+                    "skipping liquidation: insufficient collateral and no makers available"
+                );
+            }
+        }
     }
 
     /// Attempt spot liquidation with Jupiter swap
@@ -2189,7 +2264,7 @@ impl LiquidateWithMatchStrategy {
     }
 }
 
-impl LiquidationStrategy for LiquidateWithMatchStrategy {
+impl LiquidationStrategy for PrimaryLiquidationStrategy {
     fn liquidate_user<'a>(
         &'a self,
         liquidatee: Pubkey,

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -1341,7 +1341,7 @@ fn spawn_liquidation_worker(
                 .get(&liquidatee)
                 .is_some_and(|last| slot.abs_diff(*last) < LIQUIDATION_SLOT_RATE_LIMIT)
             {
-                log::info!(target: TARGET, "rate limited liquidation for {:?} (current: {})", liquidatee, slot);
+                log::warn!(target: TARGET, "rate limited liquidation for {:?} (current: {})", liquidatee, slot);
                 continue;
             } else {
                 rate_limit.insert(liquidatee, slot);

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -18,7 +18,10 @@ use tokio::sync::mpsc::error::TryRecvError;
 use drift_rs::{
     dlob::{DLOBNotifier, DLOB},
     ffi::{OraclePriceData, SimplifiedMarginCalculation},
-    grpc::{grpc_subscriber::AccountFilter, TransactionUpdate},
+    grpc::{
+        grpc_subscriber::{AccountFilter, GrpcConnectionOpts},
+        TransactionUpdate,
+    },
     jupiter::SwapMode,
     market_state::MarketStateData,
     priority_fee_subscriber::PriorityFeeSubscriber,
@@ -1200,6 +1203,7 @@ async fn setup_grpc(
                 .into(),
             std::env::var("GRPC_X_TOKEN").expect("GRPC_X_TOKEN set"),
             GrpcSubscribeOpts::default()
+                .connection_opts(GrpcConnectionOpts::default().enable_compression())
                 .commitment(solana_sdk::commitment_config::CommitmentLevel::Processed)
                 .transaction_include_accounts(vec![drift.wallet().default_sub_account()])
                 .on_transaction(on_transaction_update_fn(transaction_tx.clone()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,9 @@ pub struct Config {
     pub dry: bool,
     #[clap(long, default_value = "0")]
     pub sub_account_id: u16,
+    /// Disable Pyth price feed subscription
+    #[clap(long, default_value = "false")]
+    pub no_pyth: bool,
 }
 
 enum UseMarkets {

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,9 @@ pub struct Config {
     /// Run perp liquidator bot
     #[clap(long, default_value = "false")]
     pub liquidator: bool,
+    /// Use spot liquidation in liquidator
+    #[clap(long, action = clap::ArgAction::Set, default_value_t = true)]
+    pub use_spot_liquidation: bool,
     /// Run perp filler bot
     #[clap(long, default_value = "true")]
     pub filler: bool,
@@ -53,6 +56,9 @@ pub struct Config {
     pub dry: bool,
     #[clap(long, default_value = "0")]
     pub sub_account_id: u16,
+    /// Disable Pyth price feed subscription
+    #[clap(long, default_value = "false")]
+    pub no_pyth: bool,
 }
 
 enum UseMarkets {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,9 @@ pub struct Config {
     /// Comma-separated list of perp market indices to fill for
     #[clap(long, env = "MARKET_IDS", default_value = "0,1,2")]
     pub market_ids: String,
+    /// Comma-separated list of subaccount IDs to use for liquidations
+    #[clap(long, env = "SUBACCOUNTS", default_value = "0,1,2")]
+    pub subaccounts: String,
     /// Use mainnet (otherwise devnet)
     #[clap(long, env = "MAINNET", default_value = "true")]
     pub mainnet: bool,
@@ -79,6 +82,13 @@ impl Config {
                     .collect(),
             )
         }
+    }
+
+    pub fn get_subaccounts(&self) -> Vec<u16> {
+        self.subaccounts
+            .split(',')
+            .filter_map(|s| s.trim().parse::<u16>().ok())
+            .collect()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ pub struct Config {
     #[clap(long, default_value = "false")]
     pub liquidator: bool,
     /// Use spot liquidation in liquidator
-    #[clap(long, action = clap::ArgAction::Set, default_value_t = true)]
+    #[clap(long, env = "USE_SPOT_LIQUIDATION", default_value = "true")]
     pub use_spot_liquidation: bool,
     /// Run perp filler bot
     #[clap(long, default_value = "true")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,9 @@ pub struct Config {
     /// Comma-separated list of perp market indices to fill for
     #[clap(long, env = "MARKET_IDS", default_value = "0,1,2")]
     pub market_ids: String,
+    /// Comma-separated list of subaccount IDs to use for liquidations
+    #[clap(long, env = "SUBACCOUNTS", default_value = "0")]
+    pub subaccounts: String,
     /// Use mainnet (otherwise devnet)
     #[clap(long, env = "MAINNET", default_value = "true")]
     pub mainnet: bool,
@@ -55,7 +58,7 @@ pub struct Config {
     #[clap(long, env = "DRY_RUN", default_value = "false")]
     pub dry: bool,
     #[clap(long, default_value = "0")]
-    pub sub_account_id: u16,
+    pub sub_account_id: u16, // Redundant but used by filler bot currently
     /// Disable Pyth price feed subscription
     #[clap(long, default_value = "false")]
     pub no_pyth: bool,
@@ -79,6 +82,13 @@ impl Config {
                     .collect(),
             )
         }
+    }
+
+    pub fn get_subaccounts(&self) -> Vec<u16> {
+        self.subaccounts
+            .split(',')
+            .filter_map(|s| s.trim().parse::<u16>().ok())
+            .collect()
     }
 }
 
@@ -126,12 +136,7 @@ async fn main() {
     .expect("loaded BOT_PRIVATE_KEY")
     .into();
 
-    let keeper_subaccount = wallet.default_sub_account();
-    log::info!(
-        "bot started: authority={:?}, subaccount={:?}",
-        wallet.authority(),
-        keeper_subaccount
-    );
+    log::info!("bot started: authority={:?}", wallet.authority(),);
     log::info!("mainnet={}, markets={}", config.mainnet, config.all_markets);
 
     let context = if config.mainnet {

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ pub struct Config {
     #[clap(long, env = "MARKET_IDS", default_value = "0,1,2")]
     pub market_ids: String,
     /// Comma-separated list of subaccount IDs to use for liquidations
-    #[clap(long, env = "SUBACCOUNTS", default_value = "0,1,2")]
+    #[clap(long, env = "SUBACCOUNTS", default_value = "0")]
     pub subaccounts: String,
     /// Use mainnet (otherwise devnet)
     #[clap(long, env = "MAINNET", default_value = "true")]
@@ -58,7 +58,7 @@ pub struct Config {
     #[clap(long, env = "DRY_RUN", default_value = "false")]
     pub dry: bool,
     #[clap(long, default_value = "0")]
-    pub sub_account_id: u16,
+    pub sub_account_id: u16, // Redundant but used by filler bot currently
     /// Disable Pyth price feed subscription
     #[clap(long, default_value = "false")]
     pub no_pyth: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,12 +136,7 @@ async fn main() {
     .expect("loaded BOT_PRIVATE_KEY")
     .into();
 
-    let keeper_subaccount = wallet.default_sub_account();
-    log::info!(
-        "bot started: authority={:?}, subaccount={:?}",
-        wallet.authority(),
-        keeper_subaccount
-    );
+    log::info!("bot started: authority={:?}", wallet.authority(),);
     log::info!("mainnet={}, markets={}", config.mainnet, config.all_markets);
 
     let context = if config.mainnet {

--- a/src/util.rs
+++ b/src/util.rs
@@ -131,6 +131,10 @@ pub enum TxIntent {
         liquidatee: Pubkey,
         slot: u64,
     },
+    Derisk {
+        market_index: u16,
+        subaccount: Pubkey,
+    },
 }
 
 impl TxIntent {
@@ -156,6 +160,7 @@ impl TxIntent {
             TxIntent::LiquidateWithFill { .. } => "liq_with_fill",
             TxIntent::LiquidatePerp { .. } => "liq_perp",
             TxIntent::LiquidateSpot { .. } => "liq_spot",
+            TxIntent::Derisk { .. } => "derisk",
         }
     }
 
@@ -173,6 +178,7 @@ impl TxIntent {
             TxIntent::LiquidateWithFill { .. } => 1,
             TxIntent::LiquidatePerp { .. } => 0,
             TxIntent::LiquidateSpot { .. } => 0,
+            TxIntent::Derisk { .. } => 0,
         }
     }
 
@@ -198,6 +204,7 @@ impl TxIntent {
             Self::LiquidateWithFill { slot, .. } => (vec![], *slot),
             Self::LiquidatePerp { slot, .. } => (vec![], *slot),
             Self::LiquidateSpot { slot, .. } => (vec![], *slot),
+            TxIntent::Derisk { .. } => (vec![], 0),
         }
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -120,6 +120,11 @@ pub enum TxIntent {
         liquidatee: Pubkey,
         slot: u64,
     },
+    LiquidatePerp {
+        market_index: u16,
+        liquidatee: Pubkey,
+        slot: u64,
+    },
     LiquidateSpot {
         asset_market_index: u16,
         liability_market_index: u16,
@@ -149,6 +154,7 @@ impl TxIntent {
             TxIntent::LimitUncross { .. } => "limit_uncross",
             TxIntent::VAMMTakerFill { .. } => "vamm_taker",
             TxIntent::LiquidateWithFill { .. } => "liq_with_fill",
+            TxIntent::LiquidatePerp { .. } => "liq_perp",
             TxIntent::LiquidateSpot { .. } => "liq_spot",
         }
     }
@@ -165,6 +171,7 @@ impl TxIntent {
             TxIntent::VAMMTakerFill { .. } => 1,
             TxIntent::LimitUncross { .. } => 1,
             TxIntent::LiquidateWithFill { .. } => 1,
+            TxIntent::LiquidatePerp { .. } => 0,
             TxIntent::LiquidateSpot { .. } => 0,
         }
     }
@@ -189,6 +196,7 @@ impl TxIntent {
             Self::VAMMTakerFill { slot, .. } => (vec![], *slot),
             Self::LimitUncross { slot, .. } => (vec![], *slot),
             Self::LiquidateWithFill { slot, .. } => (vec![], *slot),
+            Self::LiquidatePerp { slot, .. } => (vec![], *slot),
             Self::LiquidateSpot { slot, .. } => (vec![], *slot),
         }
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -147,6 +147,10 @@ pub enum TxIntent {
         market_index: u16,
         subaccount: Pubkey,
     },
+    SettlePnl {
+        market_index: u16,
+        subaccount: Pubkey,
+    },
 }
 
 impl TxIntent {
@@ -175,6 +179,7 @@ impl TxIntent {
             TxIntent::LiquidateBorrowForPerpPnl { .. } => "liq_borrow_for_perp_pnl",
             TxIntent::LiquidateSpot { .. } => "liq_spot",
             TxIntent::Derisk { .. } => "derisk",
+            TxIntent::SettlePnl { .. } => "settle_pnl",
         }
     }
 
@@ -195,6 +200,7 @@ impl TxIntent {
             TxIntent::LiquidateBorrowForPerpPnl { .. } => 0,
             TxIntent::LiquidateSpot { .. } => 0,
             TxIntent::Derisk { .. } => 0,
+            TxIntent::SettlePnl { .. } => 0,
         }
     }
 
@@ -223,6 +229,7 @@ impl TxIntent {
             Self::LiquidateBorrowForPerpPnl { slot, .. } => (vec![], *slot),
             Self::LiquidateSpot { slot, .. } => (vec![], *slot),
             TxIntent::Derisk { .. } => (vec![], 0),
+            TxIntent::SettlePnl { .. } => (vec![], 0),
         }
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -21,7 +21,7 @@ use pyth_lazer_protocol::{
         Channel, DeliveryFormat, FixedRate, Format, JsonBinaryEncoding, PriceFeedId,
         PriceFeedProperty, SubscriptionParams, SubscriptionParamsRepr, TimestampUs,
     },
-    subscription::{SubscribeRequest, SubscriptionId},
+    subscription::{Response, SubscribeRequest, SubscriptionId},
 };
 use solana_sdk::signature::Signature;
 
@@ -459,7 +459,11 @@ pub fn subscribe_price_feeds(
                         }
                     }
                     _other => {
-                        log::warn!(target: "pyth", "unknown msg: {_other:?}");
+                        if let Ok(AnyResponse::Json(Response::Subscribed(sub))) = _other {
+                            log::info!(target: "pyth", "subscribed feed {}", sub.subscription_id.0);
+                        } else {
+                            log::warn!(target: "pyth", "unknown msg: {_other:?}");
+                        }
                     }
                 }
             }

--- a/src/util.rs
+++ b/src/util.rs
@@ -235,7 +235,7 @@ impl PendingTxMeta {
 /// let confirmed = buf.confirm(|m| m.signature == sig);
 /// ```
 pub struct PendingTxs<const N: usize> {
-    buffer: [PendingTxMeta; N],
+    buffer: Box<[PendingTxMeta; N]>,
     head: usize,
     tail: usize,
     size: usize,
@@ -244,7 +244,7 @@ pub struct PendingTxs<const N: usize> {
 impl<const N: usize> PendingTxs<N> {
     pub fn new() -> Self {
         Self {
-            buffer: [(); N].map(|_| PendingTxMeta::default()),
+            buffer: Box::new([(); N].map(|_| PendingTxMeta::default())),
             head: 0,
             tail: 0,
             size: 0,

--- a/src/util.rs
+++ b/src/util.rs
@@ -91,7 +91,7 @@ impl<const N: usize> OrderSlotLimiter<N> {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Default, Debug)]
 pub enum TxIntent {
     #[default]
     None,
@@ -122,6 +122,18 @@ pub enum TxIntent {
     },
     LiquidatePerp {
         market_index: u16,
+        liquidatee: Pubkey,
+        slot: u64,
+    },
+    LiquidatePerpPnlForDeposit {
+        perp_market_index: u16,
+        spot_market_index: u16,
+        liquidatee: Pubkey,
+        slot: u64,
+    },
+    LiquidateBorrowForPerpPnl {
+        perp_market_index: u16,
+        spot_market_index: u16,
         liquidatee: Pubkey,
         slot: u64,
     },
@@ -159,6 +171,8 @@ impl TxIntent {
             TxIntent::VAMMTakerFill { .. } => "vamm_taker",
             TxIntent::LiquidateWithFill { .. } => "liq_with_fill",
             TxIntent::LiquidatePerp { .. } => "liq_perp",
+            TxIntent::LiquidatePerpPnlForDeposit { .. } => "liq_perp_pnl_for_deposit",
+            TxIntent::LiquidateBorrowForPerpPnl { .. } => "liq_borrow_for_perp_pnl",
             TxIntent::LiquidateSpot { .. } => "liq_spot",
             TxIntent::Derisk { .. } => "derisk",
         }
@@ -177,6 +191,8 @@ impl TxIntent {
             TxIntent::LimitUncross { .. } => 1,
             TxIntent::LiquidateWithFill { .. } => 1,
             TxIntent::LiquidatePerp { .. } => 0,
+            TxIntent::LiquidatePerpPnlForDeposit { .. } => 0,
+            TxIntent::LiquidateBorrowForPerpPnl { .. } => 0,
             TxIntent::LiquidateSpot { .. } => 0,
             TxIntent::Derisk { .. } => 0,
         }
@@ -203,6 +219,8 @@ impl TxIntent {
             Self::LimitUncross { slot, .. } => (vec![], *slot),
             Self::LiquidateWithFill { slot, .. } => (vec![], *slot),
             Self::LiquidatePerp { slot, .. } => (vec![], *slot),
+            Self::LiquidatePerpPnlForDeposit { slot, .. } => (vec![], *slot),
+            Self::LiquidateBorrowForPerpPnl { slot, .. } => (vec![], *slot),
             Self::LiquidateSpot { slot, .. } => (vec![], *slot),
             TxIntent::Derisk { .. } => (vec![], 0),
         }
@@ -213,6 +231,9 @@ impl TxIntent {
             Self::VAMMTakerFill { slot, .. }
             | Self::LimitUncross { slot, .. }
             | Self::LiquidateWithFill { slot, .. }
+            | Self::LiquidatePerp { slot, .. }
+            | Self::LiquidatePerpPnlForDeposit { slot, .. }
+            | Self::LiquidateBorrowForPerpPnl { slot, .. }
             | Self::LiquidateSpot { slot, .. } => Some(*slot),
             _ => None,
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -21,7 +21,7 @@ use pyth_lazer_protocol::{
         Channel, DeliveryFormat, FixedRate, Format, JsonBinaryEncoding, PriceFeedId,
         PriceFeedProperty, SubscriptionParams, SubscriptionParamsRepr, TimestampUs,
     },
-    subscription::{SubscribeRequest, SubscriptionId},
+    subscription::{Response, SubscribeRequest, SubscriptionId},
 };
 use solana_sdk::signature::Signature;
 
@@ -502,7 +502,11 @@ pub fn subscribe_price_feeds(
                         }
                     }
                     _other => {
-                        log::warn!(target: "pyth", "unknown msg: {_other:?}");
+                        if let Ok(AnyResponse::Json(Response::Subscribed(sub))) = _other {
+                            log::info!(target: "pyth", "subscribed feed {}", sub.subscription_id.0);
+                        } else {
+                            log::warn!(target: "pyth", "unknown msg: {_other:?}");
+                        }
                     }
                 }
             }

--- a/src/util.rs
+++ b/src/util.rs
@@ -91,7 +91,7 @@ impl<const N: usize> OrderSlotLimiter<N> {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Default, Debug)]
 pub enum TxIntent {
     #[default]
     None,
@@ -120,11 +120,36 @@ pub enum TxIntent {
         liquidatee: Pubkey,
         slot: u64,
     },
+    LiquidatePerp {
+        market_index: u16,
+        liquidatee: Pubkey,
+        slot: u64,
+    },
+    LiquidatePerpPnlForDeposit {
+        perp_market_index: u16,
+        spot_market_index: u16,
+        liquidatee: Pubkey,
+        slot: u64,
+    },
+    LiquidateBorrowForPerpPnl {
+        perp_market_index: u16,
+        spot_market_index: u16,
+        liquidatee: Pubkey,
+        slot: u64,
+    },
     LiquidateSpot {
         asset_market_index: u16,
         liability_market_index: u16,
         liquidatee: Pubkey,
         slot: u64,
+    },
+    Derisk {
+        market_index: u16,
+        subaccount: Pubkey,
+    },
+    SettlePnl {
+        market_index: u16,
+        subaccount: Pubkey,
     },
 }
 
@@ -149,7 +174,12 @@ impl TxIntent {
             TxIntent::LimitUncross { .. } => "limit_uncross",
             TxIntent::VAMMTakerFill { .. } => "vamm_taker",
             TxIntent::LiquidateWithFill { .. } => "liq_with_fill",
+            TxIntent::LiquidatePerp { .. } => "liq_perp",
+            TxIntent::LiquidatePerpPnlForDeposit { .. } => "liq_perp_pnl_for_deposit",
+            TxIntent::LiquidateBorrowForPerpPnl { .. } => "liq_borrow_for_perp_pnl",
             TxIntent::LiquidateSpot { .. } => "liq_spot",
+            TxIntent::Derisk { .. } => "derisk",
+            TxIntent::SettlePnl { .. } => "settle_pnl",
         }
     }
 
@@ -165,7 +195,12 @@ impl TxIntent {
             TxIntent::VAMMTakerFill { .. } => 1,
             TxIntent::LimitUncross { .. } => 1,
             TxIntent::LiquidateWithFill { .. } => 1,
+            TxIntent::LiquidatePerp { .. } => 0,
+            TxIntent::LiquidatePerpPnlForDeposit { .. } => 0,
+            TxIntent::LiquidateBorrowForPerpPnl { .. } => 0,
             TxIntent::LiquidateSpot { .. } => 0,
+            TxIntent::Derisk { .. } => 0,
+            TxIntent::SettlePnl { .. } => 0,
         }
     }
 
@@ -189,7 +224,12 @@ impl TxIntent {
             Self::VAMMTakerFill { slot, .. } => (vec![], *slot),
             Self::LimitUncross { slot, .. } => (vec![], *slot),
             Self::LiquidateWithFill { slot, .. } => (vec![], *slot),
+            Self::LiquidatePerp { slot, .. } => (vec![], *slot),
+            Self::LiquidatePerpPnlForDeposit { slot, .. } => (vec![], *slot),
+            Self::LiquidateBorrowForPerpPnl { slot, .. } => (vec![], *slot),
             Self::LiquidateSpot { slot, .. } => (vec![], *slot),
+            TxIntent::Derisk { .. } => (vec![], 0),
+            TxIntent::SettlePnl { .. } => (vec![], 0),
         }
     }
 
@@ -198,6 +238,9 @@ impl TxIntent {
             Self::VAMMTakerFill { slot, .. }
             | Self::LimitUncross { slot, .. }
             | Self::LiquidateWithFill { slot, .. }
+            | Self::LiquidatePerp { slot, .. }
+            | Self::LiquidatePerpPnlForDeposit { slot, .. }
+            | Self::LiquidateBorrowForPerpPnl { slot, .. }
             | Self::LiquidateSpot { slot, .. } => Some(*slot),
             _ => None,
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -87,7 +87,7 @@ impl<const N: usize> OrderSlotLimiter<N> {
             }
         }
 
-        return true;
+        true
     }
 }
 


### PR DESCRIPTION
Here we can check the field `slots_before_stale_for_amm` to make sure we're not sending stale txs in. The sdk does this with `isFallbackAvailableLiquiditySource` [linked here](https://github.com/drift-labs/protocol-v2/blob/55bcbe47122d85c81fa1dc5df5d50a09e6960ec8/sdk/src/math/auction.ts#L32) (which we could add to the rust sdk one day? ) but I'm just checking it more directly here