### PR TITLE
fix keeper account lookup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Build Stage ----
-FROM rust:1.87.0 AS builder
+FROM rust:1.88.0 AS builder
 WORKDIR /app
 
 ENV CARGO_DRIFT_FFI_PATH="/usr/local/lib"

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -2921,7 +2921,7 @@ impl PrimaryLiquidationStrategy {
             );
 
             // Fetch accounts once
-            let keeper_account_data = match drift.try_get_account::<User>(&subaccount) {
+            let keeper_account_data = match drift.get_user_account(&subaccount).await {
                 Ok(data) => data,
                 Err(_) => {
                     log::info!(target: TARGET, "keeper account not found: {:?}", &subaccount);


### PR DESCRIPTION
- keeper is always idle (by design), so it's excluded from the initial sync and `try_get_account` fails
- use `get_user_account` instead to fall back to RPC