### PR TITLE
feat: resolve bankruptcy in liquidation flow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_and_test:
     runs-on: ubicloud
-    container: rust:1.87.0
+    container: rust:1.94.0
     timeout-minutes: 10
     strategy:
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,6 +369,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +432,15 @@ name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "arc-swap"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "ark-bn254"
@@ -596,6 +614,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atomicwrites"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef1bb8d1b645fe38d51dfc331d720fb5fc2c94b440c76cc79c80ff265ca33e3"
+dependencies = [
+ "rustix 0.38.44",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,6 +702,20 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.16",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
 ]
 
 [[package]]
@@ -964,7 +1007,12 @@ version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1284,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1294,11 +1342,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -1308,9 +1355,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -1336,6 +1383,16 @@ name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
 
 [[package]]
 name = "derivation-path"
@@ -1483,6 +1540,12 @@ dependencies = [
  "yellowstone-grpc-client",
  "yellowstone-grpc-proto",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ed25519"
@@ -1696,6 +1759,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,7 +1948,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap",
+ "indexmap 2.11.4",
  "slab",
  "tokio",
  "tokio-util",
@@ -1977,6 +2049,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,6 +2119,16 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
 
 [[package]]
 name = "hyper"
@@ -2132,6 +2223,30 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2255,12 +2370,25 @@ checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2283,6 +2411,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2545,6 +2682,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2635,6 +2784,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2710,6 +2869,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-derive"
@@ -2903,7 +3068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.11.4",
 ]
 
 [[package]]
@@ -2979,6 +3144,12 @@ checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -3107,6 +3278,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf-codegen"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace"
+dependencies = [
+ "anyhow",
+ "once_cell",
+ "protobuf",
+ "protobuf-parse",
+ "regex",
+ "tempfile",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-json-mapping"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d6e4be637b310d8a5c02fa195243328e2d97fa7df1127a27281ef1187fcb1d"
+dependencies = [
+ "protobuf",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-parse"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
+dependencies = [
+ "anyhow",
+ "indexmap 2.11.4",
+ "log",
+ "protobuf",
+ "protobuf-support",
+ "tempfile",
+ "thiserror 1.0.69",
+ "which",
+]
+
+[[package]]
 name = "protobuf-src"
 version = "1.1.0+21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3166,37 +3379,69 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-client"
-version = "0.1.3"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b5b95001b63b629226862bc79737439563654edcb72e85017a2c0827bfbf1da"
+checksum = "1907704795856be386127fbe700b226b4798dbf384d274f3392eb050b98208f1"
 dependencies = [
  "anyhow",
+ "arc-swap",
+ "async-trait",
+ "atomicwrites",
+ "backoff",
  "base64 0.22.1",
  "derive_more",
+ "fs-err",
+ "futures",
  "futures-util",
+ "humantime-serde",
+ "protobuf-json-mapping",
  "pyth-lazer-protocol",
+ "pyth-lazer-publisher-sdk",
+ "reqwest",
  "serde",
  "serde_json",
+ "serde_with",
  "tokio",
+ "tokio-stream",
  "tokio-tungstenite 0.20.1",
  "tracing",
+ "ttl_cache",
  "url",
 ]
 
 [[package]]
 name = "pyth-lazer-protocol"
-version = "0.7.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6445dc5d2f7fff7c677fb8edc5a080a82ef7583c1bdb39daa95421788c23f695"
+checksum = "856ae095d54dfc95add233f98ccdf80d50bfa26f1babb74d4969b3ecc37d17d8"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
  "byteorder",
+ "chrono",
  "derive_more",
+ "hex",
+ "humantime",
+ "humantime-serde",
  "itertools 0.13.0",
  "protobuf",
  "rust_decimal",
  "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "utoipa",
+]
+
+[[package]]
+name = "pyth-lazer-publisher-sdk"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbbe54922998c4b4931d26366f04e1d27982be03f316d7b6caf1c42c131edac8"
+dependencies = [
+ "anyhow",
+ "fs-err",
+ "protobuf",
+ "protobuf-codegen",
+ "pyth-lazer-protocol",
  "serde_json",
 ]
 
@@ -3414,6 +3659,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3484,6 +3749,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -3618,6 +3884,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
@@ -3625,7 +3904,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -3696,6 +3975,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3850,19 +4153,28 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.15.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093cd8c01b25262b84927e0f7151692158fab02d961e04c979d3903eba7ecc5"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.11.4",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
  "serde_core",
+ "serde_json",
  "serde_with_macros",
+ "time",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "3.15.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7e6c180db0816026a61afa1cff5344fb7ebded7e4d3062772179f2501481c27"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -6215,7 +6527,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.2",
  "windows-sys 0.61.2",
 ]
 
@@ -6266,6 +6578,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -6432,7 +6775,7 @@ version = "0.23.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3effe7c0e86fdff4f69cdd2ccc1b96f933e24811c5441d44904e8683e27184b"
 dependencies = [
- "indexmap",
+ "indexmap 2.11.4",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -6540,7 +6883,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.11.4",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -6633,6 +6976,15 @@ name = "tstr_proc_macros"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78122066b0cb818b8afd08f7ed22f7fdbc3e90815035726f0840d0d26c0747a"
+
+[[package]]
+name = "ttl_cache"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4189890526f0168710b6ee65ceaedf1460c48a14318ceec933cb26baa492096a"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "tungstenite"
@@ -6769,6 +7121,30 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+dependencies = [
+ "indexmap 2.11.4",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "uuid"
@@ -6933,6 +7309,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6964,6 +7352,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6982,8 +7405,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -6996,12 +7419,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3379,9 +3379,9 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-client"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1907704795856be386127fbe700b226b4798dbf384d274f3392eb050b98208f1"
+checksum = "66517a481261911b1734db49d3d1fe982cb0b75e699599c078c5ed80732f2444"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3411,9 +3411,9 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-protocol"
-version = "0.29.0"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856ae095d54dfc95add233f98ccdf80d50bfa26f1babb74d4969b3ecc37d17d8"
+checksum = "b43d0cbec773a60211db705bc446079986f755f38e15d005ed50e5356a9626bc"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -3427,15 +3427,16 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
+ "strum",
  "thiserror 2.0.17",
  "utoipa",
 ]
 
 [[package]]
 name = "pyth-lazer-publisher-sdk"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbe54922998c4b4931d26366f04e1d27982be03f316d7b6caf1c42c131edac8"
+checksum = "6f8e16c762ba3b05fd5ef2f2b4be6a71f210ada0de3a0fbb3240573243b23017"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -6442,6 +6443,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ log = { version = "0.4", features = ["max_level_trace"] }
 futures-util = "0.3.31"
 mimalloc = "0.1.47"
 prometheus = "*"
-pyth-lazer-client = "0.1.3"
-pyth-lazer-protocol = "0.7.3"
+pyth-lazer-client = "18.0.0"
+pyth-lazer-protocol = "0.29.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 solana-account-decoder-client-types = "2.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ log = { version = "0.4", features = ["max_level_trace"] }
 futures-util = "0.3.31"
 mimalloc = "0.1.47"
 prometheus = "*"
-pyth-lazer-client = "18.0.0"
-pyth-lazer-protocol = "0.29.0"
+pyth-lazer-client = "19.0.0"
+pyth-lazer-protocol = "0.30.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 solana-account-decoder-client-types = "2.3"

--- a/src/filler.rs
+++ b/src/filler.rs
@@ -122,11 +122,12 @@ impl FillerBot {
 
         let pyth_price_feed = if !config.no_pyth {
             let pyth_access_token = std::env::var("PYTH_LAZER_TOKEN").expect("pyth access token");
-            let pyth_feed_cli = pyth_lazer_client::LazerClient::new(
-                "wss://pyth-lazer.dourolabs.app/v1/stream",
-                pyth_access_token.as_str(),
-            )
-            .expect("pyth price feed connects");
+            let pyth_feed_cli =
+                pyth_lazer_client::stream_client::PythLazerStreamClientBuilder::new(
+                    pyth_access_token,
+                )
+                .build()
+                .expect("pyth price feed connects");
             let feed = crate::util::subscribe_price_feeds(pyth_feed_cli, &market_ids, &[]);
             log::info!(target: TARGET, "subscribed pyth price feeds");
             Some(feed)

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -6,17 +6,19 @@
 //!
 //! The default strategy tries to liquidate perp positions against resting orders
 //!
-use anchor_lang::Discriminator;
+use anchor_lang::{Discriminator, InstructionData};
 use dashmap::DashMap;
 use futures_util::FutureExt;
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     sync::{Arc, RwLock},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use tokio::sync::mpsc::error::TryRecvError;
 
 use drift_rs::{
+    build_accounts,
+    constants::{self, state_account},
     dlob::{DLOBNotifier, DLOB},
     ffi::{calculate_claimable_pnl, OraclePriceData, SimplifiedMarginCalculation},
     grpc::{
@@ -40,11 +42,15 @@ use drift_rs::{
         MarginRequirementType, MarketId, MarketStatus, MarketType, OracleSource, OrderParams,
         OrderType, PerpPosition, PositionDirection, SpotBalanceType, SpotPosition,
     },
-    DriftClient, GrpcSubscribeOpts, MarketState, Pubkey, TransactionBuilder,
+    DriftClient, GrpcSubscribeOpts, MarketState, Pubkey, TransactionBuilder, Wallet,
 };
 use drift_rs::{jupiter::JupiterSwapApi, titan::TitanSwapApi};
 use solana_sdk::{
-    account::Account, clock::Slot, compute_budget::ComputeBudgetInstruction, signature::Signature,
+    account::Account,
+    clock::Slot,
+    compute_budget::ComputeBudgetInstruction,
+    instruction::{AccountMeta, Instruction},
+    signature::Signature,
 };
 
 use crate::{
@@ -412,6 +418,14 @@ fn check_margin_status(margin_info: &SimplifiedMarginCalculation) -> UserMarginS
     };
 
     UserMarginStatus { cross, isolated }
+}
+
+fn user_needs_bankruptcy_resolution(user: &User) -> bool {
+    user.is_bankrupt()
+        || user
+            .perp_positions
+            .iter()
+            .any(|position| position.is_isolated_position() && (position.position_flag & 0b00000100) > 0)
 }
 
 /// Outcome of a liquidation attempt, used to drive backoff decisions
@@ -975,7 +989,7 @@ impl LiquidatorBot {
                                 users.remove(&pubkey);
                             } else {
                                 let status = check_margin_status(&margin_info);
-                                if status.is_liquidatable() {
+                                if status.is_liquidatable() || user_needs_bankruptcy_resolution(&user) {
                                     // log::debug!(target: TARGET, "found liquidatable user: {pubkey:?}, margin:{margin_info:?}");
                                     high_risk.insert(pubkey);
                                 } else if status.is_at_risk() {
@@ -1105,7 +1119,9 @@ impl LiquidatorBot {
                         };
 
                         let status = check_margin_status(&margin_info);
-                        if status.is_liquidatable() {
+                        if status.is_liquidatable()
+                            || user_needs_bankruptcy_resolution(&user_meta.user)
+                        {
                             // log::debug!(target: TARGET, "found liquidatable user: {pubkey:?}, margin:{margin_info:?}");
                             liquidatable_users.push((pubkey, user_meta.user.clone(), status));
                         }
@@ -1295,7 +1311,9 @@ impl LiquidatorBot {
 
                     let status = check_margin_status(&margin_info);
 
-                    if status.is_liquidatable() {
+                    if status.is_liquidatable()
+                        || user_needs_bankruptcy_resolution(&user_meta.user)
+                    {
                         high_risk.insert(*pubkey);
                         newly_high_risk += 1;
                         log::info!(target: TARGET, "found liquidatable user: {pubkey:?}, margin:{margin_info:?}");
@@ -3402,6 +3420,208 @@ impl PrimaryLiquidationStrategy {
         .await;
     }
 
+    fn find_perp_bankrupting_markets(user: &User) -> Vec<u16> {
+        let mut markets = BTreeSet::new();
+        for position in user.perp_positions.iter().filter(|p| !p.is_available()) {
+            if position.quote_asset_amount < 0 {
+                markets.insert(position.market_index);
+            }
+        }
+        markets.into_iter().collect()
+    }
+
+    fn find_spot_bankrupting_markets(user: &User) -> Vec<u16> {
+        let mut markets = BTreeSet::new();
+        for position in user.spot_positions.iter().filter(|p| !p.is_available()) {
+            if position.balance_type == SpotBalanceType::Borrow && position.scaled_balance > 0 {
+                markets.insert(position.market_index);
+            }
+        }
+        markets.into_iter().collect()
+    }
+
+    async fn resolve_bankruptcy(
+        drift: &DriftClient,
+        subaccounts: &[Pubkey],
+        liquidatee: Pubkey,
+        user_account: Arc<User>,
+        tx_sender: TxSender,
+        priority_fee: u64,
+        cu_limit: u32,
+        slot: u64,
+        pyth_price_update: Option<PythPriceUpdate>,
+    ) -> bool {
+        let Some(subaccount) = subaccounts.first().copied() else {
+            log::warn!(target: TARGET, "no subaccount configured for bankruptcy resolution");
+            return false;
+        };
+
+        let keeper_account_data = match drift.try_get_account::<User>(&subaccount) {
+            Ok(data) => data,
+            Err(_) => {
+                log::warn!(target: TARGET, "keeper account lookup failed for bankruptcy resolution");
+                return false;
+            }
+        };
+
+        let user_ref = user_account.as_ref();
+        let mut sent_any = false;
+        let perp_markets = Self::find_perp_bankrupting_markets(user_ref);
+        let spot_markets = Self::find_spot_bankrupting_markets(user_ref);
+
+        let quote_market = match drift
+            .program_data()
+            .spot_market_config_by_index(MarketId::QUOTE_SPOT.index())
+        {
+            Some(market) => market,
+            None => {
+                log::warn!(target: TARGET, "quote spot market unavailable for bankruptcy resolution");
+                return false;
+            }
+        };
+
+        if quote_market.has_transfer_hook() {
+            log::warn!(target: TARGET, "quote spot market has transfer hook; skipping perp bankruptcy resolution");
+        } else {
+            for market_index in perp_markets {
+                let mut tx_builder = TransactionBuilder::new(
+                    drift.program_data(),
+                    subaccount,
+                    std::borrow::Cow::Owned(keeper_account_data.clone()),
+                    false,
+                )
+                .with_priority_fee(priority_fee, Some(cu_limit));
+
+                if let Some(ref update) = pyth_price_update {
+                    tx_builder = tx_builder
+                        .post_pyth_lazer_oracle_update(&[update.feed_id], &update.message);
+                }
+
+                let mut accounts = build_accounts(
+                    drift.program_data(),
+                    drift_rs::types::accounts::ResolvePerpBankruptcy {
+                        state: *state_account(),
+                        authority: *drift.wallet.authority(),
+                        liquidator: subaccount,
+                        liquidator_stats: Wallet::derive_stats_account(&drift.wallet.authority()),
+                        user: liquidatee,
+                        user_stats: Wallet::derive_stats_account(&user_ref.authority),
+                        spot_market_vault: quote_market.vault,
+                        insurance_fund_vault: quote_market.insurance_fund.vault,
+                        drift_signer: constants::derive_drift_signer(),
+                        token_program: quote_market.token_program(),
+                    },
+                    [&keeper_account_data, user_ref].into_iter(),
+                    std::iter::empty(),
+                    [MarketId::QUOTE_SPOT, MarketId::perp(market_index)].iter(),
+                );
+                accounts.push(AccountMeta::new_readonly(quote_market.mint, false));
+
+                let ix = Instruction {
+                    program_id: constants::PROGRAM_ID,
+                    accounts,
+                    data: InstructionData::data(&drift_rs::drift_idl::instructions::ResolvePerpBankruptcy {
+                        quote_spot_market_index: MarketId::QUOTE_SPOT.index(),
+                        market_index,
+                    }),
+                };
+
+                let tx = tx_builder.add_ix(ix).build();
+                if tx_sender
+                    .send_tx(
+                        tx,
+                        TxIntent::ResolvePerpBankruptcy {
+                            market_index,
+                            liquidatee,
+                            slot,
+                        },
+                        cu_limit as u64,
+                    )
+                    .await
+                    .is_some()
+                {
+                    sent_any = true;
+                }
+            }
+        }
+
+        for market_index in spot_markets {
+            let Some(spot_market) = drift.program_data().spot_market_config_by_index(market_index)
+            else {
+                continue;
+            };
+
+            if spot_market.has_transfer_hook() {
+                log::warn!(
+                    target: TARGET,
+                    "spot market {} has transfer hook; skipping spot bankruptcy resolution",
+                    market_index
+                );
+                continue;
+            }
+
+            let mut tx_builder = TransactionBuilder::new(
+                drift.program_data(),
+                subaccount,
+                std::borrow::Cow::Owned(keeper_account_data.clone()),
+                false,
+            )
+            .with_priority_fee(priority_fee, Some(cu_limit));
+
+            if let Some(ref update) = pyth_price_update {
+                tx_builder =
+                    tx_builder.post_pyth_lazer_oracle_update(&[update.feed_id], &update.message);
+            }
+
+            let mut accounts = build_accounts(
+                drift.program_data(),
+                drift_rs::types::accounts::ResolveSpotBankruptcy {
+                    state: *state_account(),
+                    authority: *drift.wallet.authority(),
+                    liquidator: subaccount,
+                    liquidator_stats: Wallet::derive_stats_account(&drift.wallet.authority()),
+                    user: liquidatee,
+                    user_stats: Wallet::derive_stats_account(&user_ref.authority),
+                    spot_market_vault: spot_market.vault,
+                    insurance_fund_vault: spot_market.insurance_fund.vault,
+                    drift_signer: constants::derive_drift_signer(),
+                    token_program: spot_market.token_program(),
+                },
+                [&keeper_account_data, user_ref].into_iter(),
+                std::iter::empty(),
+                std::iter::once(&MarketId::spot(market_index)),
+            );
+            accounts.push(AccountMeta::new_readonly(spot_market.mint, false));
+
+            let ix = Instruction {
+                program_id: constants::PROGRAM_ID,
+                accounts,
+                data: InstructionData::data(
+                    &drift_rs::drift_idl::instructions::ResolveSpotBankruptcy { market_index },
+                ),
+            };
+
+            let tx = tx_builder.add_ix(ix).build();
+            if tx_sender
+                .send_tx(
+                    tx,
+                    TxIntent::ResolveSpotBankruptcy {
+                        market_index,
+                        liquidatee,
+                        slot,
+                    },
+                    cu_limit as u64,
+                )
+                .await
+                .is_some()
+            {
+                sent_any = true;
+            }
+        }
+
+        sent_any
+    }
+
     // Settle perp pnl
     async fn settle_perp_pnl(
         drift: &DriftClient,
@@ -3480,6 +3700,30 @@ impl LiquidationStrategy for PrimaryLiquidationStrategy {
 
         let (safest_perp_tier, safest_spot_tier) =
             Self::get_safest_tiers(&user_account, &self.drift);
+
+        if user_needs_bankruptcy_resolution(&user_account) {
+            return async move {
+                let sent = Self::resolve_bankruptcy(
+                    &self.drift,
+                    self.subaccounts.as_slice(),
+                    liquidatee,
+                    Arc::clone(&user_account),
+                    tx_sender,
+                    priority_fee,
+                    cu_limit,
+                    slot,
+                    pyth_price_update,
+                )
+                .await;
+
+                if sent {
+                    LiquidationOutcome::TxSent
+                } else {
+                    LiquidationOutcome::Skipped("bankruptcy_resolution_not_sent")
+                }
+            }
+            .boxed();
+        }
 
         let Some((liability, asset)) = Self::pick_best_asset_liability_combo(
             Arc::clone(&self.market_state),

--- a/src/liquidator.rs
+++ b/src/liquidator.rs
@@ -218,8 +218,7 @@ fn validate_data_freshness(
 /// Validate Pyth price freshness
 fn validate_pyth_price_freshness(pyth_update: &PythPriceUpdate) -> Result<(), StalenessError> {
     let now_ms = current_time_millis();
-    // Pyth timestamp is in microseconds, convert to milliseconds
-    let pyth_ts_ms = pyth_update.ts.0 / 1000;
+    let pyth_ts_ms = pyth_update.ts.as_millis();
     let age_ms = now_ms.saturating_sub(pyth_ts_ms);
 
     if age_ms > MAX_PYTH_AGE_MS {
@@ -638,11 +637,10 @@ impl LiquidatorBot {
         let market_state = Arc::new(RwLock::new(MarketState::new(market_state)));
 
         let pyth_access_token = std::env::var("PYTH_LAZER_TOKEN").expect("pyth access token");
-        let pyth_feed_cli = pyth_lazer_client::LazerClient::new(
-            "wss://pyth-lazer.dourolabs.app/v1/stream",
-            pyth_access_token.as_str(),
-        )
-        .expect("pyth price feed connects");
+        let pyth_feed_cli =
+            pyth_lazer_client::stream_client::PythLazerStreamClientBuilder::new(pyth_access_token)
+                .build()
+                .expect("pyth price feed connects");
 
         let pyth_price_feed: tokio::sync::mpsc::Receiver<_> = if config.use_spot_liquidation {
             crate::util::subscribe_price_feeds(pyth_feed_cli, &perp_market_ids, &spot_market_ids)

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,16 +12,16 @@ use drift_rs::{
     types::{MarketId, MarketType},
     Pubkey,
 };
-use futures_util::StreamExt;
-use pyth_lazer_client::AnyResponse;
+use pyth_lazer_client::ws_connection::AnyResponse;
 use pyth_lazer_protocol::{
+    api::{
+        Channel, DeliveryFormat, Format, JsonBinaryEncoding, MarketSession, SubscribeRequest,
+        SubscriptionId, SubscriptionParams, SubscriptionParamsRepr, WsResponse,
+    },
     message::Message,
     payload::{PayloadData, PayloadPropertyValue},
-    router::{
-        Channel, DeliveryFormat, FixedRate, Format, JsonBinaryEncoding, PriceFeedId,
-        PriceFeedProperty, SubscriptionParams, SubscriptionParamsRepr, TimestampUs,
-    },
-    subscription::{Response, SubscribeRequest, SubscriptionId},
+    time::{FixedRate, TimestampUs},
+    PriceFeedId, PriceFeedProperty,
 };
 use solana_sdk::signature::Signature;
 
@@ -358,8 +358,8 @@ pub struct PythPriceUpdate {
 fn fixed_rate(feed_id: u32) -> FixedRate {
     match feed_id {
         1 | 2 | 6 => FixedRate::MIN,
-        10 => FixedRate::from_ms(50).unwrap(),
-        _ => FixedRate::from_ms(200).unwrap(),
+        10 => FixedRate::RATE_50_MS,
+        _ => FixedRate::RATE_200_MS,
     }
 }
 
@@ -384,7 +384,7 @@ fn to_price_precision(price: u64, feed_id: u32, market_type: MarketType) -> u64 
 }
 
 pub fn subscribe_price_feeds(
-    mut cli: pyth_lazer_client::LazerClient,
+    mut cli: pyth_lazer_client::stream_client::PythLazerStreamClient,
     perp_market_ids: &[MarketId],
     spot_market_ids: &[MarketId],
 ) -> tokio::sync::mpsc::Receiver<PythPriceUpdate> {
@@ -435,31 +435,32 @@ pub fn subscribe_price_feeds(
             };
 
             // sub per feed
-            let mut sub_id = 0;
+            let mut sub_id = 0u64;
             for feed_id in feed_ids.iter() {
                 let subscribe_request = SubscribeRequest {
                     subscription_id: SubscriptionId(sub_id),
                     params: SubscriptionParams::new(SubscriptionParamsRepr {
-                        price_feed_ids: vec![*feed_id],
+                        price_feed_ids: Some(vec![*feed_id]),
+                        symbols: None,
                         // drift program requires exponent field to verify the message
-                        properties: vec![PriceFeedProperty::Price, PriceFeedProperty::Exponent],
+                        properties: vec![
+                            PriceFeedProperty::Price,
+                            PriceFeedProperty::Exponent,
+                            PriceFeedProperty::FeedUpdateTimestamp,
+                        ],
                         delivery_format: DeliveryFormat::Binary,
                         json_binary_encoding: JsonBinaryEncoding::Hex,
                         parsed: false,
                         channel: Channel::FixedRate(fixed_rate(feed_id.0)),
                         formats: vec![Format::Solana],
-                        ignore_invalid_feed_ids: false,
+                        ignore_invalid_feeds: false,
+                        market_sessions: vec![MarketSession::Regular],
                     })
                     .expect("invalid subscription params"),
                 };
                 sub_id += 1;
-                if let Err(err) = cli
-                    .subscribe(pyth_lazer_protocol::subscription::Request::Subscribe(
-                        subscribe_request,
-                    ))
-                    .await
-                {
-                    log::error!(target: "pyth", "pyth feed subscribe failed: {err:?}");
+                if let Err(err) = cli.subscribe(subscribe_request).await {
+                    log::error!(target: "filler", "pyth feed subscribe failed: {err:?}");
                     tokio::time::sleep(Duration::from_secs(1)).await;
                     continue;
                 }
@@ -467,10 +468,10 @@ pub fn subscribe_price_feeds(
 
             retries = 0u32; // retry on successful connect
 
-            let mut stream = pyth_lazer_stream.boxed();
-            while let Some(update) = stream.next().await {
+            let mut stream = pyth_lazer_stream;
+            while let Some(update) = stream.recv().await {
                 match update {
-                    Ok(AnyResponse::Binary(outer)) => {
+                    AnyResponse::Binary(outer) => {
                         for message in outer.messages {
                             match message {
                                 Message::Solana(solana) => {
@@ -486,7 +487,8 @@ pub fn subscribe_price_feeds(
                                             {
                                                 // TODO: bulk msg to avoid bouncing around tokio, bucket in some way, one message updates multiple markets...
                                                 let feed_id = f.feed_id.0;
-                                                let price: u64 = new_price.0.unsigned_abs().into();
+                                                let price: u64 =
+                                                    new_price.mantissa_i64().unsigned_abs();
 
                                                 if let Some(market_id) =
                                                     pyth_lazer_feed_id_to_perp_market_index(feed_id)
@@ -532,24 +534,18 @@ pub fn subscribe_price_feeds(
                         }
                     }
                     other => match other {
-                        Ok(AnyResponse::Json(Response::Subscribed(sub))) => {
+                        AnyResponse::Json(WsResponse::Subscribed(sub)) => {
                             log::info!(
                                 target: "pyth",
                                 "subscribed feed {}",
                                 sub.subscription_id.0
                             );
                         }
-                        Ok(AnyResponse::Json(msg)) => {
+                        AnyResponse::Json(msg) => {
                             log::info!(target: "pyth", "control msg: {msg:?}");
                         }
-                        Err(err) => {
-                            log::warn!(
-                                target: "pyth",
-                                "websocket error from pyth stream: {err:?}"
-                            );
-                        }
-                        Ok(other_ok) => {
-                            log::info!(target: "pyth", "non-binary msg: {other_ok:?}");
+                        AnyResponse::Binary(_) => {
+                            // already handled above; only Json variants reach this branch
                         }
                     },
                 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -454,7 +454,6 @@ pub fn subscribe_price_feeds(
                         channel: Channel::FixedRate(fixed_rate(feed_id.0)),
                         formats: vec![Format::Solana],
                         ignore_invalid_feeds: false,
-                        market_sessions: vec![MarketSession::Regular],
                     })
                     .expect("invalid subscription params"),
                 };

--- a/src/util.rs
+++ b/src/util.rs
@@ -143,6 +143,16 @@ pub enum TxIntent {
         liquidatee: Pubkey,
         slot: u64,
     },
+    ResolvePerpBankruptcy {
+        market_index: u16,
+        liquidatee: Pubkey,
+        slot: u64,
+    },
+    ResolveSpotBankruptcy {
+        market_index: u16,
+        liquidatee: Pubkey,
+        slot: u64,
+    },
     Derisk {
         market_index: u16,
         subaccount: Pubkey,
@@ -178,6 +188,8 @@ impl TxIntent {
             TxIntent::LiquidatePerpPnlForDeposit { .. } => "liq_perp_pnl_for_deposit",
             TxIntent::LiquidateBorrowForPerpPnl { .. } => "liq_borrow_for_perp_pnl",
             TxIntent::LiquidateSpot { .. } => "liq_spot",
+            TxIntent::ResolvePerpBankruptcy { .. } => "resolve_perp_bankruptcy",
+            TxIntent::ResolveSpotBankruptcy { .. } => "resolve_spot_bankruptcy",
             TxIntent::Derisk { .. } => "derisk",
             TxIntent::SettlePnl { .. } => "settle_pnl",
         }
@@ -199,6 +211,8 @@ impl TxIntent {
             TxIntent::LiquidatePerpPnlForDeposit { .. } => 0,
             TxIntent::LiquidateBorrowForPerpPnl { .. } => 0,
             TxIntent::LiquidateSpot { .. } => 0,
+            TxIntent::ResolvePerpBankruptcy { .. } => 0,
+            TxIntent::ResolveSpotBankruptcy { .. } => 0,
             TxIntent::Derisk { .. } => 0,
             TxIntent::SettlePnl { .. } => 0,
         }
@@ -228,6 +242,8 @@ impl TxIntent {
             Self::LiquidatePerpPnlForDeposit { slot, .. } => (vec![], *slot),
             Self::LiquidateBorrowForPerpPnl { slot, .. } => (vec![], *slot),
             Self::LiquidateSpot { slot, .. } => (vec![], *slot),
+            Self::ResolvePerpBankruptcy { slot, .. } => (vec![], *slot),
+            Self::ResolveSpotBankruptcy { slot, .. } => (vec![], *slot),
             TxIntent::Derisk { .. } => (vec![], 0),
             TxIntent::SettlePnl { .. } => (vec![], 0),
         }
@@ -241,7 +257,9 @@ impl TxIntent {
             | Self::LiquidatePerp { slot, .. }
             | Self::LiquidatePerpPnlForDeposit { slot, .. }
             | Self::LiquidateBorrowForPerpPnl { slot, .. }
-            | Self::LiquidateSpot { slot, .. } => Some(*slot),
+            | Self::LiquidateSpot { slot, .. }
+            | Self::ResolvePerpBankruptcy { slot, .. }
+            | Self::ResolveSpotBankruptcy { slot, .. } => Some(*slot),
             _ => None,
         }
     }
@@ -253,7 +271,9 @@ impl TxIntent {
             | Self::LiquidatePerp { liquidatee, .. }
             | Self::LiquidatePerpPnlForDeposit { liquidatee, .. }
             | Self::LiquidateBorrowForPerpPnl { liquidatee, .. }
-            | Self::LiquidateSpot { liquidatee, .. } => Some(*liquidatee),
+            | Self::LiquidateSpot { liquidatee, .. }
+            | Self::ResolvePerpBankruptcy { liquidatee, .. }
+            | Self::ResolveSpotBankruptcy { liquidatee, .. } => Some(*liquidatee),
             _ => None,
         }
     }
@@ -267,6 +287,8 @@ impl TxIntent {
                 | Self::LiquidatePerpPnlForDeposit { .. }
                 | Self::LiquidateBorrowForPerpPnl { .. }
                 | Self::LiquidateSpot { .. }
+                | Self::ResolvePerpBankruptcy { .. }
+                | Self::ResolveSpotBankruptcy { .. }
         )
     }
 }


### PR DESCRIPTION
## Summary
- enqueue users that are liquidatable or already bankrupt so the worker can process bankruptcy recovery paths
- add explicit perp and spot bankruptcy resolution transactions before normal liquidation attempts
- record bankruptcy resolution tx intents alongside existing liquidation tx intents for consistent tracking

## Test plan
- [x] `cargo check --bin keeprs`
- [ ] run liquidator against staging and verify resolve bankruptcy txs are emitted for bankrupt users
- [ ] confirm users with isolated bankrupt flags can be recovered via resolver path

Made with [Cursor](https://cursor.com)