### PR TITLE
chore: rename drift-labs GitHub URLs to velocity-exchange

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install libdrift_ffi
         run: |
-          SO_URL=$(curl -s https://api.github.com/repos/drift-labs/drift-ffi-sys/releases/latest | jq -r '.assets[] | select(.name=="libdrift_ffi_sys.so") | .browser_download_url')
+          SO_URL=$(curl -s https://api.github.com/repos/velocity-exchange/drift-ffi-sys/releases/latest | jq -r '.assets[] | select(.name=="libdrift_ffi_sys.so") | .browser_download_url')
           echo "downloading libdrift: $SO_URL"
           curl -L -o libdrift_ffi_sys.so "$SO_URL"
           cp libdrift_ffi_sys.so $CARGO_DRIFT_FFI_PATH

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 description = "Rust keeper bots for Drift protocol"
 license = "MIT"
-repository = "https://github.com/drift-labs/keep-rs"
+repository = "https://github.com/velocity-exchange/keep-rs"
 keywords = ["drift", "defi", "solana", "trading-bot", "liquidity"]
 categories = ["financial", "network-programming"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install jq -y && rustup component add rustfmt
 # RUN mkdir src && echo "fn main() {}" > src/main.rs
 
 # install libdrift
-RUN SO_URL=$(curl -s https://api.github.com/repos/drift-labs/drift-ffi-sys/releases/latest | jq -r '.assets[] | select(.name=="libdrift_ffi_sys.so") | .browser_download_url') &&\
+RUN SO_URL=$(curl -s https://api.github.com/repos/velocity-exchange/drift-ffi-sys/releases/latest | jq -r '.assets[] | select(.name=="libdrift_ffi_sys.so") | .browser_download_url') &&\
     curl -L -o libdrift_ffi_sys.so "$SO_URL" &&\
     cp libdrift_ffi_sys.so $CARGO_DRIFT_FFI_PATH
 


### PR DESCRIPTION
Part of renaming the GitHub org drift-labs -> velocity-exchange.

**DRAFT — do not merge until the velocity-exchange org (and, where applicable, the @velocity-exchange npm scope) exists; old URLs currently redirect.**

## URL forms changed

- `github.com/drift-labs/` → `github.com/velocity-exchange/` in:
  - CI workflow `repository:` checkout fields (drift-rs, protocol-v2-shadow) — 4 workflow files, 3 occurrences each
  - CI workflow `owner:` field for `actions/create-github-app-token` — 4 workflow files
  - GitHub API release download URL for `drift-ffi-sys` — `Dockerfile` and `build-and-test.yml`
  - `Cargo.toml` `repository` metadata field
  - `Cargo.lock` git-source entries for `drift-macros`, `jupiter-swap-api-client`, `titan-swap-api-client`
  - `velocity-publish.yml` comment referencing `infrastructure-v3`

Total substitutions: 19 across 7 files.

## Skipped (upstream-Drift historical refs)

- `src/liquidator.rs:2253`: `// Port of https://github.com/drift-labs/protocol-v2/...` — attribution comment crediting the original upstream Drift Protocol v2 source for ported logic; not this org's own resource.

## No @drift-labs npm scope changes

No `@drift-labs/` npm scope deps or imports were found in this repo.